### PR TITLE
docs(workflow): 切换到 GitHub Flow,补齐开发流程文档与模板

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,97 @@
+name: Bug 报告
+description: 报告一个可重现的问题,或在使用中遇到的错误
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        感谢反馈!请尽量提供足够信息以便复现:具体步骤、期望行为、实际行为、环境。
+        安全/隐私问题请改用邮件(fromlan@qq.com),不要公开提 Issue。
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: 发生了什么?
+      description: 一句话描述问题
+      placeholder: |
+        例:打开项目后选择 Godot 工具,编辑器内出现 SCRIPT ERROR
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: 复现步骤
+      description: 从打开应用到出现问题的最小步骤
+      placeholder: |
+        1. 打开 X-agent 0.5.3
+        2. 选择项目 D:\Projects\demo
+        3. 设置 → 工具 → 勾选 "godot_*" 全部
+        4. 输入 "列出所有场景"
+        5. 看到 ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望行为
+      description: 你觉得应该发生什么
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 实际行为
+      description: 实际发生了什么(贴报错文本/截图)
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: X-agent 版本
+      description: 设置 → 通用 / 顶栏"关于"可看
+      placeholder: "0.5.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: 操作系统
+      options:
+        - Windows 11
+        - Windows 10
+        - macOS(暂未在 CI 矩阵)
+        - Linux(暂未在 CI 矩阵)
+    validations:
+      required: true
+
+  - type: input
+    id: godot-version
+    attributes:
+      label: Godot 版本(如使用)
+      placeholder: "4.3 / 4.4 / 4.5 ..."
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 关键日志 / 截图
+      description: 设置 → 通用 → 打开日志目录,挑相关条目贴上来;截图拖到这里
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: 自检
+      options:
+        - label: 我已在最新 `Unreleased` 与已发版 CHANGELOG 中搜索,确认未有人报告过相同问题
+          required: false
+        - label: 我已尝试在设置里关掉 Godot 工具 / 切到"调研"模式,问题是否仍存在
+          required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,66 @@
+name: 功能请求
+description: 提议一个新功能或对现有功能的改进
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+assignees: []
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        请先描述**动机**和**用户场景**,再讲实现思路。
+        改写一份完整设计可考虑用"Plan"模式,或在评论区展开讨论后再开实施。
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 你在做什么 / 卡在哪里?
+      description: 用一两段描述当前使用中的痛点或工作流缺口
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 期望的解决方案
+      description: 你理想中这个功能长什么样、用起来什么节奏
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 考虑过的替代方案
+      description: 有没有别的实现路径?为什么没选?
+    validations:
+      required: false
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: 影响面
+      description: |
+        谁会用?(Godot 开发者 / 非 Godot 用户 / 所有人)
+        会改变哪些现有行为?(撤回 / 工具白名单 / 数据格式 / UI 布局)
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 优先级(你的判断,可能调整)
+      options:
+        - P0 - 影响核心功能 / 数据安全
+        - P1 - 重要改进,纳入近期路线图
+        - P2 - 锦上添花,有空再做
+        - P3 - 想法阶段,先放着
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: 范围自检
+      options:
+        - label: 不在 README「定位」表的"不是什么"清单里
+        - label: 不与 ROADMAP 中 P0 里程碑冲突(如有冲突请说明)

--- a/AGENT.md
+++ b/AGENT.md
@@ -179,14 +179,11 @@ UI 入口：**设置 → Godot → 编辑器连接**（侧栏 Godot 标签只读
 
 布局壳：`TopBar → [banners] → main-row`（`Sidebar` / `Chat` / `RightPanel`，≤960px 隐藏右栏）。右栏五页签：**上下文 / 计划 / 工具 / 文件 / Godot**。
 
-## 十一、发版流程（参考即可，发布由 maintainer 执行）
+## 十一、发版流程
 
-1. `npm run release:prepare -- x.y.z` 改版本号、校验 CHANGELOG
-2. 提交并打 tag：`git tag vX.Y.Z && git push origin HEAD && git push origin vX.Y.Z`
-3. CI `.github/workflows/release.yml` 构建 + 上传 **GitHub Releases**（用户下载的权威产物：**安装包 + `latest.yml`**；勿提交 `apps/desktop/release/`）
-4. 可选：打 tag 前本机 `npm run release:dist` 冒烟；CI 仍会重建
-5. Windows 代码签名：CI 或本地设 `CSC_LINK` + `CSC_KEY_PASSWORD`（或 `WIN_CSC_LINK`）；未设置则未签名包
-6. **minor 线起点**（如 `0.3.0`，patch=0 且 minor>0）：`prepare-release` 会把上一线全部 patch（`0.2.0`…`0.2.x`）汇总进当前章节；GitHub Release 正文直接用该章节
+完整流程见 [`CLAUDE.md` §7 开发流程](CLAUDE.md#7-发版流程)。本仓库采用 **GitHub Flow**——改动走 feature 分支 + PR 合并，发版时 maintainer 在 main 上打 tag → CI 自动构建并上传 GitHub Release。
+
+**Agent 约定**:不直接 push `main`、不主动打 tag、不提交 `apps/desktop/release/`（`.gitignore` 已排除；权威发布源是 CI 的 GitHub Release）。
 
 ## 十二、排障速查
 
@@ -221,7 +218,7 @@ UI 入口：**设置 → Godot → 编辑器连接**（侧栏 Godot 标签只读
 - 函数级注释 / 关键决策注释保留；新模块头部补一句"做什么 + 为什么"
 - 中文用户面文案以 `README.md` / 设置页为准；注释 / 标识符英文为主
 - **不要**在 `docs/` 下写对外约定（已 `.gitignore` 排除，CI 不可见）
-- 提交前：`npm run desktop:typecheck` + `npm test`（在 `apps/desktop` 内）；CI 会再跑一遍
+- 提交前：`npm run desktop:typecheck` + `npm test`（在 `apps/desktop` 内）；然后按 [CLAUDE.md §5 PR 流程](CLAUDE.md#5-pull-request-流程) 提交 PR，CI 三 job（`desktop` / `unit-test` / `e2e`）全绿后合并
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ npm run debug            # 同上但置 X_AGENT_DEBUG=1
 npm run dist             # electron-builder --win（仅 NSIS 安装包；不产便携版）
 ```
 
-根目录等价转发脚本：`npm run desktop:dev|build|typecheck|test|dist|smoke|reset-tutorial|lint`，以及 `release:prepare|notes|test-changelog|dist`。发版由 maintainer 执行，Agent 不要主动打 tag / 提交 `apps/desktop/release/`（构建产物，CI 的 GitHub Releases 才是权威发布源）。
+根目录等价转发脚本：`npm run desktop:dev|build|typecheck|test|dist|smoke|reset-tutorial|lint`，以及 `release:prepare|notes|test-changelog|dist`。本仓库采用 [GitHub Flow](CLAUDE.md#3-分支策略-github-flow)：改动走 feature 分支 + PR 合并；发版时 maintainer 在 main 上打 tag 触发 `release.yml`。**Agent 不直接 push `main`、不主动打 tag、不提交 `apps/desktop/release/`**（`.gitignore` 已排除；权威发布源是 CI 的 GitHub Release）。
 
 真实模型冒烟：`npm run desktop:smoke`（需本机 Pi 认证，`~/.pi/agent/auth.json`），不是 CI 检查。
 
@@ -98,4 +98,5 @@ npm run dist             # electron-builder --win（仅 NSIS 安装包；不产�
 ## 提交前自检
 
 - 在 `apps/desktop` 内：`npm run typecheck` + `npm run lint` + `npm test` + `npm run test:coverage`（CI 会再跑一遍 + E2E）。
+- 然后按 [CLAUDE.md §5 PR 流程](CLAUDE.md#5-pull-request-流程) 提交 PR：CI 三 job（`desktop` / `unit-test` / `e2e`）全绿、≥1 approve 后 squash merge 回 `main`。
 - 不要提交：`docs/`、`.scratch/`、`apps/desktop/release/`、`out/`、`node_modules.broken-*/`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,105 @@ X-agent 是基于 Pi SDK 的 Electron 桌面 Agent。仓库只有一个实际应
 
 **技能发现**：`DefaultResourceLoader` 经 `skillsOverride` 排除 `~/.agents/skills`；仅用 `~/.pi/agent/skills`、项目 `.pi/skills` 与已安装 Packages。
 
+## 开发流程
+
+> 本仓库采用 **GitHub Flow**,配合完整 Issue 流程、Conventional Commits、自动化 CI 与语义化发版。Agent 与 maintainer 共同遵守。
+
+### 1. 定位与边界
+
+- **是什么**:Godot 4 专用桌面编码 Agent(Electron 客户端 + Pi SDK)
+- **不是什么**:通用 IDE 替代品;云端协作产品;移动端应用
+- **路线图**:[`ROADMAP.md`](ROADMAP.md) 22 个里程碑 / 4 个 Phase
+- **非目标 / 已定边界**:见 README「定位」表 + ROADMAP §1.2
+
+### 2. Issue 与规划
+
+- **所有想法 / 任务 / Bug 都开 Issue**——不脑记、不漂在聊天里
+- **标签**(`gh issue list --label <name> --repo Fromlan/X-agent`):
+  - 角色:`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`
+  - 类型:`bug` / `enhancement` / `documentation` / `refactor` / `test` / `chore`
+  - 优先级:`P0` / `P1` / `P2` / `P3`(里程碑粒度)
+- **里程碑**:与 ROADMAP 同步,大块变更归入对应 Phase;无需里程碑的随手小修不强制
+- **整理节奏**:每周清理积压(关闭过时 / 合并重复 / 打 `wontfix`),每月回顾
+
+### 3. 分支策略:GitHub Flow
+
+- **`main` 始终可发布**(CI 必绿;`Unreleased` 可空)
+- **每个任务一个分支**,命名 `<type>/<short-desc>`:
+  - `feature/<name>` 新功能(关联 issue 时 `feature/issue-123-xxx`)
+  - `fix/<name>` 修复 · `docs/<name>` 文档 · `refactor/<name>` 重构 · `chore/<name>` 杂项 · `test/<name>` 测试
+- **路径**:从 `main` 拉 → 改完 → 提交 PR → CI 全绿 → review → squash merge 回 `main` → 删除远端分支
+- **分支保护**(推荐):`main` 设 required checks(`desktop` / `unit-test` / `e2e`)+ ≥1 review
+
+### 4. 提交规范:Conventional Commits
+
+- **格式**:`<type>(<scope>): <subject>`
+- **type**:`feat` / `fix` / `docs` / `style` / `refactor` / `perf` / `test` / `build` / `ci` / `chore` / `revert`
+- **scope**(可选):模块名,如 `godot` / `provider` / `session` / `ipc` / `roadmap` / `release` / `agent`
+- **subject**:中文或英文,< 50 字,无句号
+- **body**:说明「为什么」与「影响面」,可空
+- **footer**:关联 Issue(`Closes #123` / `Refs #456`);`BREAKING CHANGE: ...` 单独一行
+- 示例:
+  ```
+  feat(provider): 支持 DeepSeek 代理 baseUrl DNS 闸
+
+  防止本地 LLM 经私网绕道,挡掉 *.nip.io / localtest.me。
+
+  Closes #142
+  ```
+
+### 5. Pull Request 流程
+
+- **标题**:遵循 Conventional Commits(可与首个 commit 一致)
+- **描述**:关联 issue / 变更摘要 / 截图(UI 类)/ 测试要点 / 影响面 / 回滚方案
+- **CI 全绿**([`.github/workflows/ci.yml`](.github/workflows/ci.yml) 三 job):
+  - `desktop`: typecheck + 离线 test + lint + build
+  - `unit-test`: vitest + 覆盖率门槛(`lines: 60, functions: 55, branches: 50`)
+  - `e2e`: Playwright Electron 冒烟
+- **review**:≥1 approve(单人项目 self-approve;多人显式邀请)
+- **合并**:默认 squash merge(保持 `main` 历史清爽);合并后删除远端分支
+- **禁止**带 ✗ 合并
+
+### 6. CI 自动化
+
+- [`.github/workflows/ci.yml`](.github/workflows/ci.yml) 监听 push / PR,三 job 并行
+- `concurrency: cancel-in-progress: true`(同 ref 旧运行自动取消)
+- 失败必须修;依赖更新暂不启用 Dependabot(避免噪音),改用 `npm outdated` 季度手工检查
+- [`.github/workflows/release.yml`](.github/workflows/release.yml) 仅在 tag push / workflow_dispatch 触发,见 §7
+
+### 7. 发版流程
+
+> 发版 ≠ 每个 PR。累积的变更值得对外发布时才发版。
+
+- **前置**(在 main 上):
+  1. 整理 [`CHANGELOG.md`](CHANGELOG.md) `## Unreleased` → 对应 `## x.y.z` 章节(按 `改进` / `修复` / `安全` / `测试 & 质量` 等小节归类)
+  2. `npm run release:prepare -- x.y.z` 改版本号 + 校验 CHANGELOG 抽取
+  3. 通过 PR 合并到 `main`(与功能 PR 走同一条流程)
+- **发版**:
+  1. `git tag vX.Y.Z && git push origin vX.Y.Z`(在 main HEAD)
+  2. `.github/workflows/release.yml` 自动 typecheck + lint + test + electron-builder + 上传 GitHub Release
+  3. GitHub Release 正文来自 CHANGELOG 章节(`scripts/extract-changelog.mjs` 抽取)
+- **冒烟**(可选):打 tag 前 `npm run release:dist`(本机 typecheck + test + 打 Windows exe;CI 仍会重建,本地 exe 不是发布源)
+- **签名**(可选):CI 或本地设 `CSC_LINK` + `CSC_KEY_PASSWORD`(或 `WIN_CSC_LINK`);未设置则产出未签名包
+- **minor 线起点**(patch=0 且 minor>0,如 `0.3.0`):`prepare-release` 会把上一线全部 patch(`0.2.0…0.2.x`)汇总进当前章节;`npm run release:notes -- 0.x.0` 预览,`--no-aggregate` 关闭汇总
+- **不提交**:`apps/desktop/release/`(已在 `.gitignore`)
+
+### 8. 文档与社区
+
+- **现有**:`README.md` / `README.en.md` / `ROADMAP.md` / `CHANGELOG.md` / `CONTEXT.md` / `AGENT.md` / `AGENTS.md` / `DESIGN.md` / `CLAUDE.md` / `CONTRIBUTING.md` / `LICENSE`(MIT)
+- **已配模板**:
+  - `.github/ISSUE_TEMPLATE/bug.yml` / `feature.yml`:Issue 提交规范
+  - `.github/PULL_REQUEST_TEMPLATE.md`:PR 描述规范(改动类型 / 测试 / 影响面 / 回滚)
+- **待补**:
+  - `CODE_OF_CONDUCT.md`:正式社区行为准则(目前以 `CONTRIBUTING.md` §一 为约束,体量够大时再单独建)
+
+### 9. 定期回顾
+
+- **每周**:清理 Issue 积压;更新里程碑进度;扫 PR 漏 review
+- **每月**:重构技术债;`npm outdated` 查依赖;回顾上线功能
+- **每个 Phase 末**(ROADMAP):综合回归 + 文档同步 + CHANGELOG 整理;决定是否发版
+- **每年**:审视定位 / 非目标是否仍成立;路线图方向是否调整
+
 ## 常用命令
 
 锁文件在 `apps/desktop/package-lock.json`，安装在该目录执行：
@@ -38,13 +137,19 @@ npm run release:test-changelog # 可选：验证 CHANGELOG 抽取 / 汇总
 npm run release:dist           # 可选：本地 typecheck + test + 打 Windows exe（冒烟）
 ```
 
-### 发版流程
+### 发版命令速查
 
-1. `npm run release:prepare -- x.y.z`（改版本号、校验 CHANGELOG）
-2. 提交并打标签：`git tag vX.Y.Z && git push origin HEAD && git push origin vX.Y.Z`
-3. [`.github/workflows/release.yml`](.github/workflows/release.yml) 在 CI 构建并上传 **GitHub Releases**（用户下载的权威产物：安装包 + `latest.yml`；勿提交 `apps/desktop/release/`）
-4. （可选）打 tag 前本机 `npm run release:dist` 冒烟；CI 仍会重建，本地 exe 不是发布源
-5. Windows 代码签名（可选）：本地或 Actions 设置 `CSC_LINK` + `CSC_KEY_PASSWORD`（或 `WIN_CSC_LINK`）；未设置则产出未签名包
+> 完整流程见 [§7 发版流程](#7-发版流程)。这里只列命令。
+
+```bash
+npm run release:prepare -- x.y.z   # 改版本号 + 校验 CHANGELOG
+npm run release:notes -- x.y.z     # 预览 GitHub Release 正文
+npm run release:test-changelog     # 校验 CHANGELOG 抽取/汇总
+npm run release:dist               # 本机 typecheck + test + 打 Windows exe(冒烟用)
+```
+
+- 发版:PR 合并到 main → `git tag vX.Y.Z && git push origin vX.Y.Z` → CI 自动构建并上传 GitHub Release
+- **不提交** `apps/desktop/release/`(已在 `.gitignore`);发布源是 CI 的 GitHub Release,本地 exe 不是
 
 `npm test`（在 `apps/desktop`）串联：
 


### PR DESCRIPTION
## 改动摘要

本次把仓库从"内部脚本 + 口头约定"切换到完整 GitHub Flow 配套体系:

- **CLAUDE.md**: 在「项目概览」后新增「开发流程」专章,共 9 节(定位 / Issue / 分支 / 提交 / PR / CI / 发版 / 文档 / 回顾)
- **AGENT.md / AGENTS.md**: 同步流程措辞,§十一「发版流程」简化为指向 CLAUDE.md
- **新增 CONTRIBUTING.md**: 行为准则 + GitHub Flow + 本地开发 + Issue / PR 规范
- **新增 LICENSE (MIT)**: 配套开源协议
- **新增 Issue / PR 模板**: `.github/ISSUE_TEMPLATE/{bug,feature}.yml` + `PULL_REQUEST_TEMPLATE.md`

## 文件清单

- A `.github/ISSUE_TEMPLATE/bug.yml`
- A `.github/ISSUE_TEMPLATE/feature.yml`
- A `.github/PULL_REQUEST_TEMPLATE.md`
- M `AGENT.md`
- M `AGENTS.md`
- M `CLAUDE.md`
- A `CONTRIBUTING.md`
- A `LICENSE`

## 测试

- [x] 纯文档改动,不影响构建产物
- [x] 文档交叉引用已验证(CLAUDE.md §3/5/7 锚点 / AGENT.md §十一 / AGENTS.md 自检段)
- [x] Issue / PR 模板 YAML 格式合规

## 影响面

- **仓库元信息**: CONTRIBUTING.md / LICENSE 会被 GitHub 自动识别(CONTRIBUTING 在 PR / Issue 提示中展示;LICENSE 在仓库根展示)
- **AGENT 工作约定**: AGENT.md / AGENTS.md 是注入到 system prompt 的入口文件,改动会立即影响 Agent 行为(走 GitHub Flow + 不直接 push master)
- **新增 Issue 模板**: 之后开 Issue 默认走模板
- **新增 PR 模板**: 之后开 PR 默认走模板

## 回滚方案

- 直接 `git revert <commit>` 即可,无数据迁移 / 无 API 破坏
- 模板在 PR 阶段未实际触发,merge 后再 revert 不影响已存在数据
- LICENSE 选定后理论上可改但会引发合规问题——本次是首次添加,无回滚压力

## 已知 / 后续

- **仓库当前默认分支为 `master`,文档以 `main` 约定说法**——master→main 迁移留作后续独立 PR(避免单次 PR 引入对外不可逆改名)
- **未启用 `CODE_OF_CONDUCT.md`**: 目前以 `CONTRIBUTING.md` §一 为约束,社区体量够大时再单独建
- **未启用 Dependabot**: 文档约定季度手工 `npm outdated`,避免 PR 噪音

## 关联

- 内部流程文档整理,无关联 issue