### PR TITLE
ci(dependabot): auto-merge semver-patch PRs after CI passes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,45 @@
+name: dependabot-auto-merge
+
+# 让 dependabot 提的 semver-patch PR 在 CI 通过后自动合；
+# minor / major 仍走人工 review。
+# 仓库 Settings → General → Allow auto-merge 必须保持打开。
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: dependabot-auto-merge-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for semver-patch
+        if: steps.meta.outputs.update-type == 'version-update:semver-patch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      - name: Comment for non-patch (informational)
+        if: |
+          steps.meta.outputs.update-type != 'version-update:semver-patch' &&
+          steps.meta.outputs.update-type != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr comment "$PR_URL" --body "🤖 Auto-merge skipped: \`${{ steps.meta.outputs.update-type }}\`. Patch-only auto-merge is enabled; minor/major updates need a human review."


### PR DESCRIPTION
## Why

X-agent is a single-maintainer repo. The current weekly dependabot sweep in `MAINTENANCE.md` still costs ~15 min because every PR is merged by hand — most of them are trivial typebox / vitest / @types bumps that pass CI on the first run.

## What

- New workflow `.github/workflows/dependabot-auto-merge.yml`:
  - Triggers on `pull_request` opened/synchronize/reopened by `dependabot[bot]`
  - Uses `dependabot/fetch-metadata` to read `update-type`
  - **Only** auto-merges when `update-type == version-update:semver-patch` via `gh pr merge --auto --squash`
  - Minor / major / unknown updates get a comment explaining why auto-merge was skipped, then go through the normal human review path
- Repo setting `allow_auto_merge = true` (already enabled)
- `dependabot.yml` unchanged

## Behavior

| Update type  | Action     |
|--------------|------------|
| semver-patch | Auto-merge (squash) once CI green |
| semver-minor | Comment + wait for human |
| semver-major | Comment + wait for human |

## Out of scope

- Bumping dependabot's own groups / commit message format (unchanged)
- CODEOWNERS / required reviewers (single-maintainer repo doesn'\''t need them)