### PR TITLE
feat(ui): elevation-driven 主次分明改版 (v1.1 设计语言)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 
 ### 改进
 
+- **UI 主次分明与简洁直观改版（v1.1 设计语言落地）**：原"全窗单 Surface + 1px Board 切边 + 页面内 0 阴影"的扁平网格感，改为 elevation 驱动的层级式布局——Composer / 输入区作为整窗唯一主元素（`--bg-card-elev` + `--shadow-strong` + `--radius-floating` 双层阴影 + 16-20px 圆角 + 上下 16-20px 呼吸区），三栏壳层（TopBar / Sidebar / RightPanel）降为低调 chrome（统一 `--bg-chrome` 底）。
+  - **新增 5 个 elevation token + 2 个 spacing token**（`apps/desktop/src/styles/themes.css` + `app.css`）：`--bg-card-elev` / `--bg-chrome` / `--shadow-soft` / `--shadow-strong` / `--shadow-modal` / `--radius-floating` / `--space-section` / `--space-chrome`。`--shadow-sm/md/lg` 保留为 alias 指向新 token，向后兼容。10 个主题族（default / nord / tokyo / paper / contrast × dark/light）全部补齐；`contrast` 强制 `none` 保持硬边，`paper` 走最轻一档。
+  - **TopBar 浮起条**：高度 48→52px，背景 `--bg-app` → `--bg-chrome`，新增 `useScrollElevated` hook 监听 chat transcript 滚动状态，滚动时挂 `--shadow-soft`（默认 0 阴影避免常驻压感）；"打开项目"按钮提为 `btn-cta`（最高强调），其余按钮保留 ghost。
+  - **Sidebar 可折叠**：`prefs.sidebarCollapsed: boolean`（默认 false）持久化；新增 `useNarrowWindow` hook，窗口 ≤960px 时自动展开避免无入口。折叠态 56px 宽，仅显示项目首字母圆形 avatar + count badge（点击切到该项目最近会话）；展开态 group 间距从 4px 拉大到 12px，呼吸感更强；背景 `--bg-sidebar` → `--bg-chrome`。
+  - **RightPanel 垂直 nav + Context hero 提级**：水平 5 tabs → 左侧 56px 垂直 nav（`--accent-blue` 左侧 2px 高亮条 + 选中态 `--bg-card` 底），删除"工具面板"标题与头部；Context tab 的 `rp-context-hero` 单独提为主卡（`--bg-card-elev` + `--radius-floating` + `--shadow-soft`），其余 sections 退到普通 card 底，section 间 1px 横线删除改 4px gap。
+  - **Composer 升级为唯一主元素**：圆角 12px → 16-18px，背景 `--bg-input` → `--bg-card-elev`，去掉 1px color-mix mode 边线（阴影 + 提色已够强），默认 `--shadow-soft` / focus-within & streaming 升级到 `--shadow-strong`，外层 padding 12/14/14 → 18/14/16。Mode pill active 态加 1.5px inset 模式色边 + 字重 500，与 Composer 同步主次。
+  - **Chat transcript 间距 + 工具卡提级**：行间距 16px → 20px（ROW_GAP_PX + .message-stream-inner gap）；展开态 tool card / tool batch 加 `--shadow-soft` + `--bg-card` 底，折叠态 pill 模式保留原视觉不抢戏。
+  - **设置弹窗几何同步**：`.modal-panel` 圆角 12px → 16-18px，阴影 `--shadow-lg` → `--shadow-modal`，与主卡保持一致"主焦点"语义。
+  - **DESIGN.md 改稿**：§一.4 扁平分层 → elevation 分层；§五 0 阴影 → token 控制；§六 布局壳层 ASCII 图重画；§九 加 §九.7 主元素唯一性反模式；§一附主题族表更新。
 - **仓库健康流程落地（社区化与流程自动化）**：补齐开源项目健康流程所需文件——`LICENSE` (MIT)、`CONTRIBUTING.md`、`CODE_OF_CONDUCT.md` (Contributor Covenant v2.1)、`SECURITY.md`、`MAINTENANCE.md`；`.github/CODEOWNERS` 锁定路径 owner；`.github/dependabot.yml` 启用 npm + GitHub Actions 周更；`.github/ISSUE_TEMPLATE/` 三个 YAML（bug / feature / question）+ `.github/PULL_REQUEST_TEMPLATE.md` + `.github/labels.yml`（19 个标签）；commit-msg 钩 `scripts/commit-msg-lint.mjs`（17 个 case 配套测试）锁 Conventional Commits 格式；CI `actionlint` job 校验 workflow YAML；`prepare-release.mjs` 加 tag 漂移硬闸（package.json > 最新 tag 时拒绝；支持 `--force`）；`release.yml` checkout `fetch-depth: 0`；根 / `apps/desktop` / `packages/godot-pi` 的 `package.json` 补 `license` / `author` / `repository` / `bugs` / `engines`；README 中英加「反馈与贡献」小节，CLAUDE / ROADMAP 加对 `MAINTENANCE.md` 的引用。
 
 ### 移除

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,10 @@ X-agent 是基于 Pi SDK 的 Electron 桌面 Agent。仓库只有一个实际应
 - **合并**:默认 squash merge(保持 `main` 历史清爽);合并后删除远端分支
 - **禁止**带 ✗ 合并
 
+#### 5.1 GitHub 认证
+
+- **本机特殊环境（Windows + GCM Core 缺失）的 PAT 落地 / push 绕坑方法**在本地文件 [`docs/agents/env-credentials.md`](docs/agents/env-credentials.md)（gitignored，仅本机留存）。其他机器 / CI 不需要该文件，按自己正常 env 配即可。
+
 ### 6. CI 自动化
 
 - [`.github/workflows/ci.yml`](.github/workflows/ci.yml) 监听 push / PR,三 job 并行

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -7,8 +7,8 @@
 1. **深色优先**：`:root` 为深色回退；`body[data-theme="{themeId}-{colorMode}"]` 覆盖完整 token。
 2. **近单色**：默认灰阶；彩度仅用于已登记的语义信号（focus、running/warning、status、diff）。实验主题族可提高语义色饱和度。
 3. **Token 驱动**：颜色 / 圆角 / 阴影走 CSS 变量；改主题只改 token（见 `apps/desktop/src/styles/themes.css`）。
-4. **扁平分层**：全窗 Surface 底 + 1px Board 分割；抬起控件用 Card，不用背景色块切页。
-5. **零阴影**：深度靠边框与 Surface/Card 差；仅 modal 浮层可用 gated shadow。实验包可启用更强的 `--shadow-`*。
+4. **Elevation 分层（v1.1）**：以 surface / card / card-elevated / floating 四级拉开主次——全窗 Surface 底是 chrome（TopBar / Sidebar / RightPanel 外壳），Card 承载常规内容，Card-elevated + 阴影是**唯一主元素**（Composer / 右栏 Context hero），不再用"靠 1px 边线切一切"的网格式表达。
+5. **页面内温和阴影**：通过 `--shadow-soft` / `--shadow-strong` / `--shadow-modal` token 控制强度，≤ 200ms 缓动；`contrast` 主题族强制为 `none` 保持硬边。
 6. **Pill 优先**：按钮、chip、单行 input、tab 用 `9999px`；容器 12px；多行控件 8px。主题族可覆盖 `--radius-`*。
 7. **字重克制**：UI 仅 400 / 500；不用 600+。
 8. **图标**：优先 `lucide-react`；状态用色点 / 语义色，不用 emoji。
@@ -22,13 +22,13 @@
 偏好字段：`ClientPrefs.themeId` + `ClientPrefs.colorMode`（旧字段 `theme: light|dark` 读入时映射为 `default` + 对应模式；旧 `themeId: cindy` 映射为 `default`）。
 
 
-| themeId    | 说明           | 样式令牌倾向                         |
-| ---------- | ------------ | ------------------------------ |
-| `default`  | **默认**；近单色扁平 | 半径 8/12；pill 9999；页面内无阴影       |
-| `nord`     | 冷灰蓝极光        | 半径 10/14；modal 阴影略强            |
-| `tokyo`    | 深蓝夜 + 彩强调    | 半径同默认；focus 光晕更强               |
-| `paper`    | 暖纸 / 墨水      | 半径 10/14；可有极轻 `--shadow-sm/md` |
-| `contrast` | 高对比选型        | 半径 4/8；pill 弱化为 8；Board 更硬     |
+| themeId    | 说明             | 样式令牌倾向                                        |
+| ---------- | -------------- | --------------------------------------------- |
+| `default`  | **默认**；近单色 + 主次分明 | 半径 8/12/16；pill 9999；card-elev + 双层阴影；`--radius-floating: 16px` |
+| `nord`     | 冷灰蓝极光          | 半径 10/14/16；阴影同 default；card-elev 跟随冷色调           |
+| `tokyo`    | 深蓝夜 + 彩强调      | 半径同 default；focus 光晕更强；`--radius-floating: 18px`    |
+| `paper`    | 暖纸 / 墨水        | 半径 10/14/14；**阴影最轻**（`/ 5-6%`）；card-elev 暖色         |
+| `contrast` | 高对比选型          | 半径 4/8/**6**；**所有阴影 `none`**；pill 弱化为 8；Board 更硬       |
 
 
 可变样式令牌：`--radius-control` / `--radius-container` / `--radius-pill`、`--shadow-sm` / `--shadow-md` / `--shadow-lg`、全部颜色 token。字体栈不变。
@@ -45,18 +45,20 @@
 
 
 
-### 2.1 三层 Surface
+### 2.1 四层 Surface（v1.1 Elevation 分层）
 
 
-| 角色          | Light     | Dark      | Token 映射                                                          |
-| ----------- | --------- | --------- | ----------------------------------------------------------------- |
-| **Surface** | `#f8f8f6` | `#141414` | `--bg-app` / `--bg-sidebar` / `--bg-main`                         |
-| **Card**    | `#ffffff` | `#2c2c2a` | `--bg-header` / `--bg-input` / `--bg-modal` / composer            |
-| **Board**   | `#d7d7d4` | `#3c3c3a` | `--border-primary` / `--border-input`                             |
-| **Chip**    | `#e5e5e5` | `#3c3c3a` | `--bg-list-hover` / `--surface-chip`；选中用略抬升的 `--bg-list-selected` |
+| 角色              | Light     | Dark      | Token 映射                                                          | 用途                              |
+| --------------- | --------- | --------- | ----------------------------------------------------------------- | ------------------------------- |
+| **Surface**     | `#f8f8f6` | `#141414` | `--bg-app` / `--bg-sidebar` / `--bg-main`                         | 全窗底；chrome 外壳                 |
+| **Card**        | `#ffffff` | `#2c2c2a` | `--bg-header` / `--bg-input` / `--bg-modal`                       | 常规内容（气泡、tool card、settings 弹窗） |
+| **Card-elev**   | `#fbfbf7` | `#33332f` | `--bg-card-elev`                                                  | **主元素**底（Composer / 右栏 Context hero） |
+| **Chrome**      | `#ededeb` | `#1a1a1a` | `--bg-chrome`                                                     | TopBar / Sidebar / RightPanel 外壳   |
+| **Board**       | `#d7d7d4` | `#3c3c3a` | `--border-primary` / `--border-input`                             | 1px 分隔边                        |
+| **Chip**        | `#e5e5e5` | `#3c3c3a` | `--bg-list-hover` / `--surface-chip`；选中用略抬升的 `--bg-list-selected` | 次要控件底                          |
 
 
-全窗应用结构用单一 Surface，区域边界只用 1px Board，不用背景色差切页。其他主题族保持同一三层角色，仅换色值。
+主元素 = **Card-elev + 阴影 + 圆角增大**，唯一性由 token + 单一焦点区保证，不再"靠 1px 边线切一切"。其他主题族保持同一四层角色，仅换色值。
 
 ### 2.2 文本
 
@@ -172,17 +174,20 @@
 
 
 
-## 四、圆角（Cindy 默认三档；主题可覆盖）
+## 四、圆角（Cindy 默认四档；主题可覆盖）
 
 
-| Token                | Cindy  | 用途                            |
-| -------------------- | ------ | ----------------------------- |
-| `--radius-control`   | 8px    | textarea、气泡、菜单行高亮             |
-| `--radius-container` | 12px   | 卡片、代码块、模态、工具卡                 |
-| `--radius-pill`      | 9999px | 按钮、chip、单行 input、tab、nav cell |
+| Token                | Cindy  | 用途                                          |
+| -------------------- | ------ | ------------------------------------------- |
+| `--radius-control`   | 8px    | textarea、气泡、菜单行高亮                           |
+| `--radius-container` | 12px   | 卡片、代码块、模态、工具卡                              |
+| `--radius-floating`  | 16px   | **主元素**（Composer / 右栏 Context hero）        |
+| `--radius-pill`      | 9999px | 按钮、chip、单行 input、tab、nav cell             |
 
 
-兼容别名：`--radius-sm` / `--radius-md` → control；`--radius-lg` → control（气泡）；`--radius-xl` / `--radius-2xl` → container。
+兼容别名：`--radius-sm` / `--radius-md` → control；`--radius-lg` → control（气泡）；`--radius-xl` / `--radius-2xl` → container；`--radius-card` → container（v1.1 alias）。
+
+`contrast` 主题族：`--radius-floating: 6px`（高对比，pill 弱化）。
 
 ---
 
@@ -191,13 +196,17 @@
 ## 五、阴影
 
 
-| Token                         | Cindy 用途                  |
-| ----------------------------- | ------------------------- |
-| `--shadow-sm` / `--shadow-md` | `none`（页面内禁止）             |
-| `--shadow-lg`                 | 仅 settings / confirm 模态浮层 |
+| Token             | 用途 / 强度                                   |
+| ----------------- | ----------------------------------------- |
+| `--shadow-soft`   | 页面内 hover / focus 软阴影；双层 `0 1px 2px / 8%, 0 2px 8px / 6%` |
+| `--shadow-strong` | floating 主元素阴影；双层 `0 1px 2px / 8%, 0 8px 24px / 12%` |
+| `--shadow-modal`  | settings / confirm 模态浮层；`0 1px 2px / 12%, 0 12px 36px / 18%` |
+| `--shadow-sm`     | 旧 alias → `--shadow-soft`（保留兼容）           |
+| `--shadow-md`     | 旧 alias → `--shadow-strong`（保留兼容）         |
+| `--shadow-lg`     | 旧 alias → `--shadow-modal`（保留兼容）          |
 
 
-Focus 光晕用 `--focus-ring-soft`，不算装饰阴影。实验主题可调整 `--shadow-*` 数值。
+页面内阴影 ≤ 200ms 缓动，强度由 token 控制；`contrast` 主题族强制 `none` 保持硬边。Focus 光晕用 `--focus-ring-soft`，不算装饰阴影。
 
 ---
 
@@ -206,16 +215,33 @@ Focus 光晕用 `--focus-ring-soft`，不算装饰阴影。实验主题可调整
 ## 六、布局壳层
 
 ```
-TopBar → [banners] → main-row
-  ├── Sidebar（会话列表，~260px）
-  ├── Chat（模式 pill：Agent | 调研 | Plan | 目标；Shift+Tab 循环）
-  └── RightPanel（可选，~360px；默认折叠；上下文 / 计划 / 工具 / 文件 / Godot 五页签）
+┌─ TopBar（sticky 浮起条；52px；默认 0 阴影，滚动挂载 --shadow-soft）──┐
+│  [打开项目] [新会话]    <cwd 路径>           [设置] [更新] [右栏] [主题] │
+└────────────────────────────────────────────────────────────┘
+↓
+[ banners · update · retract / retract confirm ]
+↓
+┌─ Sidebar ─────┐  ┌─ Chat ──────────────────┐  ┌─ RightPanel ───┐
+│  ~260px       │  │  transcript + bubbles    │  │  56px 垂直 nav  │
+│  (可折叠到 56) │  │                          │  │  ~360px body    │
+│  视觉降权：     │  │                          │  │                 │
+│  --bg-chrome  │  │                          │  │                 │
+│               │  │  ┌─ Composer ──────────┐ │  │                 │
+│               │  │  │ 主元素: card-elev     │ │  │                 │
+│               │  │  │ + shadow-strong      │ │  │                 │
+│               │  │  │ + radius-floating    │ │  │                 │
+│               │  │  └────────────────────┘ │  │                 │
+└───────────────┘  └──────────────────────────┘  └─────────────────┘
 ```
 
-- 区域分割：`1px solid var(--border-primary)`。
-- Settings：仍为居中模态（非全屏路由）；左侧 nav 用 pill 选中态（通用 / 供应商 / 用量 / 工具 / 插件 / Godot）。
-- 右栏：`ClientPrefs.rightPanelOpen`；窄窗（≤960px）隐藏右栏。
-  - **上下文**：占用进度、组成拆解、本轮 / 会话用量；手动压缩
+- **TopBar**：sticky 浮起条；背景 `--bg-chrome`；滚动 chat transcript 时挂 `--shadow-soft`；52px 高。
+- **Sidebar**：默认 260px；`prefs.sidebarCollapsed: boolean`（默认 false）切换 56px 折叠态；视觉降权为 `--bg-chrome`；group 间距 12px；session card hover 浮起。窄窗（≤960px）强制展开。
+- **ChatPanel**：transcript + composer 垂直布局；transcript 与 composer 之间留 `--space-section`（20px）呼吸。
+- **Composer**：**唯一主元素**——`--bg-card-elev` + `--shadow-soft`（默认）→ `--shadow-strong`（focus-within） + `--radius-floating`（16-18px） + 上下 16-20px 呼吸；模式色边仅在 streaming 状态加挂。
+- **RightPanel**：head 简化为关闭按钮；56px 左侧垂直 nav（图标 + tooltip 文字），选中态加 2px mode 色条 + `--bg-card` 底；Context tab 的 hero 区单独提为 `--bg-card-elev` + `--radius-floating` + `--shadow-soft` 主卡；其余 sections 退到 `--bg-card` 底，section 间 12px 间距不再用 1px 横线。
+- **Settings**：居中模态（非全屏路由）；几何与主壳层一致（`--radius-floating`）；左侧 nav 用 pill 选中态（通用 / 供应商 / 用量 / 工具 / 插件 / Godot）。
+- **右栏**：`ClientPrefs.rightPanelOpen`；窄窗（≤960px）隐藏右栏。
+  - **上下文**：占用进度（hero 主卡）、组成拆解、本轮 / 会话用量；手动压缩
   - **计划**：Markdown 编辑、todos 勾选、保存到项目、执行计划
   - **工具**：已启用工具分组与调用详情
   - **文件**：项目文件树、预览、右键（加入对话 / 资源管理器 / 复制路径）
@@ -277,8 +303,9 @@ TopBar → [banners] → main-row
 
 1. 组件内硬编码颜色 → 用 token。
 2. 用 emoji 当 UI 图标。
-3. 页面内 `box-shadow`（除 modal / focus ring；实验主题经 token 启用的阴影除外）。
+3. 页面内 `box-shadow` 必须走 `--shadow-soft` / `--shadow-strong` / `--shadow-modal` token；硬编码 shadow 值或 `0 1px 1px` 这类临时值都属反模式（`contrast` 主题族强制 `none`）。
 4. 任意硬编码圆角（须用 `--radius-*`）或蓝实心主按钮铺满工具栏。
 5. 字重 ≥600。
 6. 渐变背景装饰。
+7. 多个元素同时抢"主元素"视觉焦点——主元素只有一个：Composer + 当前的 RightPanel hero。其它区域保持低调 chrome。
 

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -415,6 +415,11 @@ export interface ClientPrefs {
   rightPanelOpen: boolean;
   /** Left session sidebar width in px. */
   sidebarWidth: number;
+  /**
+   * Whether the left session sidebar is collapsed to icon-only mode (56px).
+   * Auto-expands below the narrow-window threshold (≤960px).
+   */
+  sidebarCollapsed?: boolean;
   /** Right tool panel width in px. */
   rightPanelWidth: number;
   /**
@@ -465,6 +470,7 @@ export const DEFAULT_PREFS: ClientPrefs = {
   godotEditorPath: null,
   rightPanelOpen: false,
   sidebarWidth: 260,
+  sidebarCollapsed: false,
   rightPanelWidth: 360,
   hiddenProjectKeys: [],
   dismissedReadyChecklistKeys: [],
@@ -508,6 +514,7 @@ export const ClientPrefsSchema = Type.Object({
   godotEditorPath: Type.Union([Type.Null(), Type.String()]),
   rightPanelOpen: Type.Boolean(),
   sidebarWidth: Type.Number(),
+  sidebarCollapsed: Type.Optional(Type.Boolean()),
   rightPanelWidth: Type.Number(),
   hiddenProjectKeys: Type.Array(Type.String()),
   dismissedReadyChecklistKeys: Type.Array(Type.String()),

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -70,6 +70,7 @@ import { usePlanSessionAutoOpen } from "./hooks/usePlanSession";
 import { useProjectReadiness } from "./hooks/useProjectReadiness";
 import { useRetractConfirm } from "./hooks/useRetractConfirm";
 import { useWorkspaceSession } from "./hooks/useWorkspaceSession";
+import { useScrollElevated } from "./hooks/useScrollElevated";
 import {
   appendPendingUser,
   createEmptyState,
@@ -144,6 +145,8 @@ export default function App() {
   );
   const usageFetchGen = useRef(0);
   const sessionIdRef = useRef<string | null>(null);
+  const chatStreamRef = useRef<HTMLDivElement | null>(null);
+  const topbarElevated = useScrollElevated(chatStreamRef);
   const usageVersion = useSyncExternalStore(
     subscribeSessionUsageStore,
     getSessionUsageStoreVersion,
@@ -930,6 +933,7 @@ export default function App() {
         rightPanelOpen={prefs?.rightPanelOpen ?? false}
         compacting={compacting}
         busy={busy}
+        elevated={topbarElevated}
       />
       {showUpdateBanner && updateStatus && (
         <UpdateBanner
@@ -1083,6 +1087,7 @@ export default function App() {
           status={status}
           apiStatus={apiStatusView}
           input={input}
+          externalStreamRef={chatStreamRef}
           setInput={setInput}
           onSend={send}
           onAbort={abort}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -71,6 +71,7 @@ import { useProjectReadiness } from "./hooks/useProjectReadiness";
 import { useRetractConfirm } from "./hooks/useRetractConfirm";
 import { useWorkspaceSession } from "./hooks/useWorkspaceSession";
 import { useScrollElevated } from "./hooks/useScrollElevated";
+import { useNarrowWindow } from "./hooks/useNarrowWindow";
 import {
   appendPendingUser,
   createEmptyState,
@@ -583,6 +584,15 @@ export default function App() {
     setPrefs(next);
   }, []);
 
+  const commitSidebarCollapsed = useCallback(async (sidebarCollapsed: boolean) => {
+    setPrefs((prev) => (prev ? { ...prev, sidebarCollapsed } : prev));
+    const next = await window.xAgent.prefs.set({ sidebarCollapsed });
+    setPrefs(next);
+  }, []);
+
+  const narrowWindow = useNarrowWindow(960);
+  const sidebarCollapsed = !narrowWindow && (prefs?.sidebarCollapsed ?? false);
+
   const commitRightPanelWidth = useCallback(async (rightPanelWidth: number) => {
     setPrefs((prev) => (prev ? { ...prev, rightPanelWidth } : prev));
     const next = await window.xAgent.prefs.set({ rightPanelWidth });
@@ -631,18 +641,30 @@ export default function App() {
   }, []);
 
   const layoutWidths = useMemo(
-    () =>
-      fitColumnWidths({
+    () => {
+      if (sidebarCollapsed) {
+        // 折叠态：sidebar 固定 56，fit 只决定 right panel 收缩
+        return fitColumnWidths({
+          viewportWidth,
+          sidebarWidth: 56,
+          rightPanelWidth,
+          rightPanelOpen: prefs?.rightPanelOpen ?? false,
+          sidebarFloor: 56,
+        });
+      }
+      return fitColumnWidths({
         viewportWidth,
         sidebarWidth,
         rightPanelWidth,
         rightPanelOpen: prefs?.rightPanelOpen ?? false,
-      }),
+      });
+    },
     [
       viewportWidth,
       sidebarWidth,
       rightPanelWidth,
       prefs?.rightPanelOpen,
+      sidebarCollapsed,
     ],
   );
 
@@ -1071,14 +1093,16 @@ export default function App() {
           busy={busy}
           compacting={compacting}
           sessionsLoading={sessionsLoading}
+          collapsed={sidebarCollapsed}
           onResume={resumeSession}
           onDelete={deleteSession}
           onDeleteProjectSessions={deleteProjectSessions}
           onHideProject={hideProject}
           onRename={renameSession}
           onRefresh={refreshSessions}
-          onResizePointerDown={onSidebarResizePointerDown}
-          onResizeDoubleClick={onSidebarResizeDoubleClick}
+          onToggleCollapsed={() => void commitSidebarCollapsed(!sidebarCollapsed)}
+          onResizePointerDown={sidebarCollapsed ? undefined : onSidebarResizePointerDown}
+          onResizeDoubleClick={sidebarCollapsed ? undefined : onSidebarResizeDoubleClick}
           resizing={sidebarResizing}
         />
         <ChatPanel

--- a/apps/desktop/src/components/ChatPanel.tsx
+++ b/apps/desktop/src/components/ChatPanel.tsx
@@ -37,6 +37,7 @@ import {
 import { useSlashMenu } from "../hooks/useSlashMenu";
 import { useAtCompletion, type AtPathCandidate } from "../hooks/useAtCompletion";
 import { ThinkingOrb } from "./ThinkingOrb";
+import type { RefObject } from "react";
 
 /** @-补全 path 候选暂未接入 file-tree IPC；空数组常量化避免每次渲染新建引用。 */
 const EMPTY_PATH_CANDIDATES: AtPathCandidate[] = [];
@@ -87,6 +88,11 @@ interface Props {
   onModelChange: (value: string) => void;
   onThinkingChange: (level: ThinkingLevel) => void;
   onToggleThinking: () => void;
+  /**
+   * Optional external ref for the chat transcript scroll container.
+   * Used by parent to track scroll position (e.g. mount TopBar shadow).
+   */
+  externalStreamRef?: RefObject<HTMLDivElement | null>;
 }
 
 /** Render an "已等待 12s" suffix when the wait exceeds 3 seconds. */
@@ -295,6 +301,7 @@ function ChatPanelImpl(props: Props) {
         planPath={props.planPath}
         onBuildPlan={props.onBuildPlan}
         onClarifySelect={props.onClarifySelect}
+        externalStreamRef={props.externalStreamRef}
       />
 
       {props.queuedSteering && props.queuedSteering.length > 0 && (

--- a/apps/desktop/src/components/ChatPanel.tsx
+++ b/apps/desktop/src/components/ChatPanel.tsx
@@ -367,7 +367,11 @@ function ChatPanelImpl(props: Props) {
       )}
 
       <div className="composer">
-        <div className="composer-shell" data-session-mode={sessionMode}>
+        <div
+          className="composer-shell"
+          data-session-mode={sessionMode}
+          data-streaming={streaming ? "true" : undefined}
+        >
           <SlashMenu
             open={menuOpen}
             items={filtered}

--- a/apps/desktop/src/components/ChatTranscript.tsx
+++ b/apps/desktop/src/components/ChatTranscript.tsx
@@ -17,7 +17,15 @@
  * virtualizer 配置已拆到 `../lib/chat-transcript-virtual.ts`,
  * 批次合并逻辑在 `../lib/chat-tool-batches.ts`。
  */
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
 import type { AgentSessionMode, AgentStatus } from "@shared/ipc";
 import type { ChatItem } from "../stores/chat-store";
 import {
@@ -114,6 +122,12 @@ export interface ChatTranscriptProps {
   planPath?: string | null;
   onBuildPlan?: () => void;
   onClarifySelect?: (reply: string) => void;
+  /**
+   * Optional external ref for the scrollable stream element.
+   * Used by parent to track scroll position (e.g. mount TopBar shadow
+   * when transcript is below the fold). Falls back to an internal ref.
+   */
+  externalStreamRef?: RefObject<HTMLDivElement | null>;
 }
 
 export function ChatTranscript(props: ChatTranscriptProps) {
@@ -122,7 +136,8 @@ export function ChatTranscript(props: ChatTranscriptProps) {
   const streaming =
     props.status === "streaming" || props.status === "retrying";
 
-  const streamRef = useRef<HTMLDivElement>(null);
+  const internalStreamRef = useRef<HTMLDivElement>(null);
+  const streamRef = props.externalStreamRef ?? internalStreamRef;
   const contentRef = useRef<HTMLDivElement>(null);
   const tailRef = useRef<HTMLDivElement | null>(null);
   const pinStateRef = useRef<ChatScrollPinState>(initialChatScrollPinState());

--- a/apps/desktop/src/components/RightPanel.tsx
+++ b/apps/desktop/src/components/RightPanel.tsx
@@ -100,38 +100,38 @@ export function RightPanel({
           title="拖动调整宽度 · 双击恢复默认"
         />
       )}
-      <div className="right-panel-head">
-        <h2 className="right-panel-title">工具面板</h2>
-        <button
-          type="button"
-          className="btn btn-ghost btn-sm btn-icon"
-          onClick={onClose}
-          title="收起工具面板"
-          aria-label="收起工具面板"
-        >
-          <PanelRightClose size={14} />
-        </button>
-      </div>
-      <nav className="rp-tabs" aria-label="面板页签">
+      <nav className="rp-nav" aria-label="面板页签">
         {TABS.map((t) => {
           const Icon = t.icon;
           return (
             <button
               key={t.id}
               type="button"
-              className={`rp-tab${state.tab === t.id ? " active" : ""}`}
+              className={`rp-nav-tab${state.tab === t.id ? " active" : ""}`}
               onClick={() => setRightPanelTab(t.id)}
+              title={t.label}
+              aria-label={t.label}
+              aria-pressed={state.tab === t.id}
             >
-              <Icon size={13} aria-hidden strokeWidth={2} />
-              <span className="rp-tab-label">{t.label}</span>
+              <Icon size={16} aria-hidden strokeWidth={2} />
               {t.id === "plan" && planPath ? (
                 <span className="rp-tab-dot" aria-hidden />
               ) : null}
             </button>
           );
         })}
+        <div className="rp-nav-spacer" aria-hidden />
+        <button
+          type="button"
+          className="btn btn-ghost btn-sm btn-icon rp-nav-close"
+          onClick={onClose}
+          title="收起工具面板"
+          aria-label="收起工具面板"
+        >
+          <PanelRightClose size={14} />
+        </button>
       </nav>
-      <div className="right-panel-body has-tabs">
+      <div className="right-panel-body">
         {state.tab === "context" && (
           <ContextTab
             usage={usage}

--- a/apps/desktop/src/components/TopBar.tsx
+++ b/apps/desktop/src/components/TopBar.tsx
@@ -23,6 +23,8 @@ interface Props {
   compacting?: boolean;
   updateStatus?: AppUpdateStatus | null;
   updateActionBusy?: boolean;
+  /** When true, mount --shadow-soft on the sticky bar (set by parent scroll listener). */
+  elevated?: boolean;
   onOpenProject: () => void;
   onNewSession: () => void;
   onToggleTheme: () => void;
@@ -34,11 +36,14 @@ interface Props {
 
 function TopBarImpl(props: Props) {
   return (
-    <header className="topbar">
+    <header
+      className="topbar"
+      data-elevated={props.elevated ? "true" : undefined}
+    >
       <div className="topbar-left">
         <button
           type="button"
-          className="btn btn-secondary btn-sm"
+          className="btn btn-cta btn-sm"
           onClick={() => props.onOpenProject()}
           disabled={props.busy}
           title="打开项目"

--- a/apps/desktop/src/components/sidebar/Sidebar.tsx
+++ b/apps/desktop/src/components/sidebar/Sidebar.tsx
@@ -4,7 +4,7 @@
  */
 import { memo } from "react";
 import type { PointerEvent as ReactPointerEvent } from "react";
-import { RefreshCw } from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen, RefreshCw } from "lucide-react";
 import type { AgentStatus, SessionInfo } from "@shared/ipc";
 import { useSidebarState } from "./useSidebarState";
 import { SidebarGroupList } from "./SidebarGroupList";
@@ -21,12 +21,15 @@ interface Props {
   compacting?: boolean;
   /** True while `listSessions` is in flight; surfaces skeleton in the list. */
   sessionsLoading?: boolean;
+  /** Collapsed to icon-only mode (56px). */
+  collapsed?: boolean;
   onResume: (path: string) => void;
   onDelete: (path: string) => void;
   onDeleteProjectSessions: (cwd: string) => void;
   onHideProject: (cwd: string, label: string) => void;
   onRename: (path: string, name: string) => void | Promise<void>;
   onRefresh: () => void;
+  onToggleCollapsed?: () => void;
   onResizePointerDown?: (e: ReactPointerEvent) => void;
   onResizeDoubleClick?: () => void;
   resizing?: boolean;
@@ -41,12 +44,14 @@ function SidebarImpl({
   busy,
   compacting = false,
   sessionsLoading = false,
+  collapsed = false,
   onResume,
   onDelete,
   onDeleteProjectSessions,
   onHideProject,
   onRename,
   onRefresh,
+  onToggleCollapsed,
   onResizePointerDown,
   onResizeDoubleClick,
   resizing = false,
@@ -68,18 +73,47 @@ function SidebarImpl({
     agentStatus === "streaming" ||
     agentStatus === "retrying";
 
+  const className = [
+    "sidebar",
+    state.menuOpen ? "is-context-menu-open" : "",
+    collapsed ? "is-collapsed" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
   return (
-    <aside className={`sidebar${state.menuOpen ? " is-context-menu-open" : ""}`}>
+    <aside className={className} data-collapsed={collapsed ? "true" : undefined}>
       <div className="sidebar-head">
-        <h2>会话</h2>
-        <button
-          type="button"
-          className="btn btn-ghost btn-icon"
-          onClick={onRefresh}
-          title="刷新"
-        >
-          <RefreshCw size={13} />
-        </button>
+        {!collapsed && <h2>会话</h2>}
+        <div className="sidebar-head-actions">
+          {!collapsed && (
+            <button
+              type="button"
+              className="btn btn-ghost btn-icon"
+              onClick={onRefresh}
+              title="刷新"
+              aria-label="刷新会话列表"
+            >
+              <RefreshCw size={13} />
+            </button>
+          )}
+          {onToggleCollapsed && (
+            <button
+              type="button"
+              className="btn btn-ghost btn-icon"
+              onClick={onToggleCollapsed}
+              title={collapsed ? "展开会话栏" : "折叠会话栏"}
+              aria-label={collapsed ? "展开会话栏" : "折叠会话栏"}
+              aria-pressed={collapsed}
+            >
+              {collapsed ? (
+                <PanelLeftOpen size={13} />
+              ) : (
+                <PanelLeftClose size={13} />
+              )}
+            </button>
+          )}
+        </div>
       </div>
       <SidebarGroupList
         state={state}
@@ -88,9 +122,10 @@ function SidebarImpl({
         locked={locked}
         loading={sessionsLoading}
         onResume={onResume}
+        collapsed={collapsed}
       />
       <SidebarItemMenu state={state} busy={busy} locked={locked} renaming={false} />
-      {onResizePointerDown && (
+      {!collapsed && onResizePointerDown && (
         <div
           className={`column-resize-handle column-resize-handle--right${resizing ? " is-dragging" : ""}`}
           onPointerDown={onResizePointerDown}

--- a/apps/desktop/src/components/sidebar/SidebarGroupList.tsx
+++ b/apps/desktop/src/components/sidebar/SidebarGroupList.tsx
@@ -10,6 +10,8 @@ interface Props {
   locked: boolean;
   /** True while `listSessions` is in flight; renders skeleton rows. */
   loading?: boolean;
+  /** Sidebar collapsed to icon-only mode. */
+  collapsed?: boolean;
   onResume: (path: string) => void;
 }
 
@@ -26,6 +28,7 @@ export function SidebarGroupList({
   agentStatus,
   locked,
   loading = false,
+  collapsed: sidebarCollapsed = false,
   onResume,
 }: Props) {
   const {
@@ -48,6 +51,15 @@ export function SidebarGroupList({
   } = state;
 
   if (groups.length === 0) {
+    if (sidebarCollapsed) {
+      return (
+        <ul className="session-list session-list-collapsed" ref={listRef}>
+          <li className="session-empty-collapsed" aria-label="暂无会话">
+            —
+          </li>
+        </ul>
+      );
+    }
     return (
       <ul className="session-list" ref={listRef}>
         {loading ? (
@@ -60,6 +72,40 @@ export function SidebarGroupList({
         ) : (
           <li className="session-empty">暂无会话记录</li>
         )}
+      </ul>
+    );
+  }
+
+  if (sidebarCollapsed) {
+    return (
+      <ul className="session-list session-list-collapsed" ref={listRef}>
+        {groups.map((group: Group) => {
+          const isActiveProject = group.key === activeKey && activeKey !== "";
+          const initial = (group.label || "?").trim().charAt(0).toUpperCase();
+          // 折叠态下点 project bubble：展开并跳到该项目最近一个 session
+          const target = group.sessions[0];
+          return (
+            <li key={group.key || "__unknown__"} className="project-group-collapsed">
+              <button
+                type="button"
+                className={`project-avatar${isActiveProject ? " is-active" : ""}`}
+                title={`${group.label} · ${group.sessions.length} 个会话`}
+                aria-label={`${group.label} · ${group.sessions.length} 个会话`}
+                disabled={!target || locked}
+                onClick={() => {
+                  if (target) onResume(target.path);
+                }}
+              >
+                <span aria-hidden>{initial}</span>
+                {group.sessions.length > 1 && (
+                  <span className="project-avatar-count tabular" aria-hidden>
+                    {group.sessions.length}
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
       </ul>
     );
   }

--- a/apps/desktop/src/hooks/useNarrowWindow.ts
+++ b/apps/desktop/src/hooks/useNarrowWindow.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Returns true when the viewport width is at or below `thresholdPx`.
+ * Used to gate auto-expand behavior (e.g. sidebar collapse disables itself
+ * on narrow windows so users still have a session entry point).
+ *
+ * Updates on `resize` (debounced via rAF) and on initial mount.
+ */
+export function useNarrowWindow(thresholdPx = 960): boolean {
+  const [narrow, setNarrow] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth <= thresholdPx;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    let raf = 0;
+    const update = () => {
+      raf = 0;
+      setNarrow(window.innerWidth <= thresholdPx);
+    };
+    const onResize = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(update);
+    };
+    update();
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [thresholdPx]);
+
+  return narrow;
+}

--- a/apps/desktop/src/hooks/useScrollElevated.ts
+++ b/apps/desktop/src/hooks/useScrollElevated.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState, type RefObject } from "react";
+
+/**
+ * Track whether a scrollable element has scrolled past a threshold.
+ * Used to mount `--shadow-soft` on the sticky TopBar only when content is
+ * actually below the fold; this avoids the constant "压感" of a permanent
+ * shadow on a bar that may have nothing to elevate against.
+ */
+export function useScrollElevated(
+  scrollRef: RefObject<HTMLElement | null>,
+  thresholdPx = 4,
+): boolean {
+  const [elevated, setElevated] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    let raf = 0;
+    const update = () => {
+      setElevated(el.scrollTop > thresholdPx);
+    };
+    const onScroll = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        update();
+      });
+    };
+
+    update();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      el.removeEventListener("scroll", onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [scrollRef, thresholdPx]);
+
+  return elevated;
+}

--- a/apps/desktop/src/lib/chat-transcript-virtual.ts
+++ b/apps/desktop/src/lib/chat-transcript-virtual.ts
@@ -13,7 +13,7 @@ import {
 export const ESTIMATE_ROW_PX = 72;
 /** Streaming estimate: markdown is still growing + tool cards can be tall. */
 export const ESTIMATE_ROW_PX_STREAMING = 120;
-export const ROW_GAP_PX = 16;
+export const ROW_GAP_PX = 20;
 /**
  * 贴底补偿阈值(px):视口距底部 ≤ 该值即视为"贴底",
  * 此后任何行的测量/尺寸变化都会同步补偿 scrollTop。

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -97,6 +97,17 @@
   --shadow-md: none;
   --shadow-lg: 0 8px 24px rgb(0 0 0 / 0.28);
 
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #33332f;
+  --bg-chrome: #1a1a1a;
+  --shadow-soft: 0 1px 2px rgb(0 0 0 / 8%), 0 2px 8px rgb(0 0 0 / 6%);
+  --shadow-strong: 0 1px 2px rgb(0 0 0 / 8%), 0 8px 24px rgb(0 0 0 / 12%);
+  --shadow-modal: 0 1px 2px rgb(0 0 0 / 12%), 0 12px 36px rgb(0 0 0 / 18%);
+  --radius-floating: 16px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
+
   --font-sans: "Inter", system-ui, -apple-system, "Segoe UI", "PingFang SC",
     "Hiragino Sans", "Microsoft YaHei", sans-serif;
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas,

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -4662,75 +4662,71 @@ body.is-resizing-column * {
 .right-panel {
   position: relative;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   min-height: 0;
   min-width: 0;
   overflow: hidden;
-  background: var(--bg-sidebar);
+  background: var(--bg-chrome);
   border-left: 1px solid var(--border-primary);
 }
 
-.right-panel-head {
+.rp-nav {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--border-primary);
-  background: var(--bg-app);
-  flex-shrink: 0;
-}
-
-.right-panel-title {
-  margin: 0;
-  font-size: 12px;
-  font-weight: 500;
-  color: var(--text-secondary);
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.rp-tabs {
-  display: flex;
   gap: 4px;
-  padding: 8px 10px;
-  border-bottom: 1px solid var(--border-primary);
+  padding: 10px 6px;
+  width: 56px;
   flex-shrink: 0;
-  background: var(--bg-app);
+  background: var(--bg-chrome);
+  border-right: 1px solid var(--border-primary);
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
-.rp-tab {
+.rp-nav-tab {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   border: 1px solid transparent;
+  border-radius: var(--radius-control);
   background: transparent;
   color: var(--text-secondary);
-  border-radius: var(--radius-pill);
-  padding: 5px 12px;
-  font-size: 12px;
-  font-weight: 500;
   cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-.rp-tab svg {
+.rp-nav-tab svg {
   flex-shrink: 0;
   opacity: 0.85;
 }
 
-.rp-tab.active svg {
-  opacity: 1;
-}
-
-.rp-tab:hover {
+.rp-nav-tab:hover {
   background: var(--bg-list-hover);
   color: var(--text-primary);
 }
 
-.rp-tab.active {
-  background: var(--surface-chip);
-  border-color: var(--border-primary);
+.rp-nav-tab.active {
+  background: var(--bg-card);
   color: var(--text-primary);
+  border-color: var(--border-primary);
+  box-shadow: inset 2px 0 0 var(--accent-blue);
+}
+
+.rp-nav-tab.active svg {
+  opacity: 1;
+}
+
+.rp-nav-spacer {
+  flex: 1 1 auto;
+  min-height: 8px;
+}
+
+.rp-nav-close {
+  margin-top: 4px;
 }
 
 .rp-tab-dot {
@@ -5149,16 +5145,11 @@ body.is-resizing-column * {
 .right-panel-body {
   flex: 1;
   min-height: 0;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   color: var(--text-muted);
-}
-
-.right-panel-body.has-tabs {
-  align-items: stretch;
-  justify-content: flex-start;
-  padding: 0;
-  text-align: left;
+  background: var(--bg-app);
 }
 
 .rp-empty {
@@ -5174,11 +5165,16 @@ body.is-resizing-column * {
   min-height: 0;
   overflow-y: auto;
   color: var(--text-primary);
+  gap: 4px;
 }
 
 .rp-context-hero {
-  padding: 14px 12px 16px;
-  border-bottom: 1px solid var(--border-primary);
+  margin: 12px 12px 16px;
+  padding: 16px 16px 18px;
+  border: 1px solid var(--border-primary);
+  border-radius: var(--radius-floating);
+  background: var(--bg-card-elev);
+  box-shadow: var(--shadow-soft);
   display: flex;
   flex-direction: column;
   gap: 12px;
@@ -5254,8 +5250,8 @@ body.is-resizing-column * {
 }
 
 .rp-context-section {
-  padding: 14px 12px 16px;
-  border-bottom: 1px solid var(--border-primary);
+  padding: 12px 12px 16px;
+  border-bottom: 0;
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -1304,7 +1304,7 @@ body.is-resizing-column * {
 .message-stream-inner {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 20px;
   min-height: 100%;
 }
 
@@ -2300,6 +2300,13 @@ body.is-resizing-column * {
   border-right: 1px solid var(--border-primary);
   border-bottom: 1px solid var(--border-primary);
   line-height: 1.3;
+  transition: box-shadow 0.15s ease;
+}
+
+/* 展开态 tool card 提为软 elevation，与 Composer 主元素呼应 */
+.bubble-tool[open] {
+  box-shadow: var(--shadow-soft);
+  background: var(--bg-card);
 }
 
 /* Collapsed: compact single-row chips so tool chains stay short */
@@ -2357,6 +2364,12 @@ body.is-resizing-column * {
   border-left: 3px solid var(--warning-accent);
   max-width: 82%;
   border-radius: var(--radius-container);
+  transition: box-shadow 0.15s ease;
+}
+
+.bubble-tool-batch[open] {
+  box-shadow: var(--shadow-soft);
+  background: var(--bg-card);
 }
 
 /* 折叠: 单行 pill */

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -2743,7 +2743,7 @@ body.is-resizing-column * {
 /* —— Composer —— */
 .composer {
   border-top: 1px solid var(--border-primary);
-  padding: 12px 14px 14px;
+  padding: 18px 14px 16px;
   background: var(--bg-app);
   flex-shrink: 0;
   min-width: 0;
@@ -2811,9 +2811,11 @@ body.is-resizing-column * {
 }
 
 .composer-mode-pill.is-active {
-  color: var(--mode-color);
-  border-color: color-mix(in srgb, var(--mode-color) 38%, var(--border-primary));
-  background: color-mix(in srgb, var(--mode-color) 16%, var(--bg-header));
+  color: var(--text-primary);
+  font-weight: 500;
+  border-color: color-mix(in srgb, var(--mode-color) 60%, transparent);
+  background: color-mix(in srgb, var(--mode-color) 18%, var(--bg-card-elev));
+  box-shadow: inset 0 0 0 1.5px color-mix(in srgb, var(--mode-color) 38%, transparent);
 }
 
 .composer-mode-pill.is-active:hover:not(:disabled) {
@@ -2884,11 +2886,12 @@ body.is-resizing-column * {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 10px 12px 10px;
-  border: 1px solid color-mix(in srgb, var(--mode-color) 35%, var(--border-primary));
-  border-radius: var(--radius-container);
-  background: var(--bg-input);
-  transition: border-color 0.12s, box-shadow 0.12s, background 0.12s;
+  padding: 12px 14px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-floating);
+  background: var(--bg-card-elev);
+  box-shadow: var(--shadow-soft);
+  transition: box-shadow 0.2s ease, background 0.2s ease, transform 0.2s ease;
 }
 
 .composer-shell[data-session-mode="agent"] {
@@ -2908,12 +2911,13 @@ body.is-resizing-column * {
 }
 
 .composer-shell:hover {
-  border-color: color-mix(in srgb, var(--mode-color) 65%, var(--border-primary));
+  box-shadow: var(--shadow-soft);
 }
 
-.composer-shell:focus-within {
-  border-color: var(--mode-color);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--mode-color) 30%, transparent);
+.composer-shell:focus-within,
+.composer-shell[data-streaming="true"] {
+  box-shadow: var(--shadow-strong);
+  border-color: color-mix(in srgb, var(--mode-color) 24%, transparent);
 }
 
 .composer-shell:has(textarea:disabled) {

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -405,15 +405,23 @@ input:not([type]):-webkit-autofill {
 }
 
 .topbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px 12px;
-  padding: 8px 12px;
-  background: var(--bg-app);
+  padding: var(--space-chrome) 14px;
+  background: var(--bg-chrome);
   border-bottom: 1px solid var(--border-primary);
-  min-height: 48px;
+  min-height: 52px;
   flex-shrink: 0;
+  transition: box-shadow 0.2s ease;
+}
+
+.topbar[data-elevated="true"] {
+  box-shadow: var(--shadow-soft);
 }
 
 .topbar-left,

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -930,17 +930,38 @@ body.is-resizing-column * {
   min-width: 0;
   overflow-y: auto;
   overflow-x: hidden;
-  background: var(--bg-sidebar);
+  background: var(--bg-chrome);
   border-right: 1px solid var(--border-primary);
+  transition: width 0.2s ease;
+}
+
+.sidebar.is-collapsed {
+  width: 56px;
 }
 
 .sidebar-head {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 8px 10px;
+  padding: var(--space-chrome);
   border-bottom: 1px solid var(--border-primary);
-  background: var(--bg-app);
+  background: var(--bg-chrome);
+}
+
+.sidebar.is-collapsed .sidebar-head {
+  justify-content: center;
+  padding: var(--space-chrome) 6px;
+}
+
+.sidebar-head-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.sidebar.is-collapsed .sidebar-head-actions {
+  width: 100%;
+  justify-content: center;
 }
 
 .sidebar-head h2 {
@@ -955,7 +976,7 @@ body.is-resizing-column * {
 .session-list {
   list-style: none;
   margin: 0;
-  padding: 6px;
+  padding: 8px;
   overflow: auto;
   flex: 1;
 }
@@ -965,7 +986,77 @@ body.is-resizing-column * {
 }
 
 .session-list > li.project-group {
-  margin: 0 0 4px;
+  margin: 0 0 12px;
+}
+
+/* —— Collapsed mode: project avatar stack —— */
+.session-list-collapsed {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 6px;
+}
+
+.project-group-collapsed {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.project-avatar {
+  position: relative;
+  width: 36px;
+  height: 36px;
+  border-radius: 9999px;
+  border: 1px solid var(--border-primary);
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s, box-shadow 0.12s;
+}
+
+.project-avatar:hover:not(:disabled) {
+  background: var(--bg-list-hover);
+  color: var(--text-primary);
+}
+
+.project-avatar.is-active {
+  background: var(--bg-list-selected);
+  color: var(--text-primary);
+  border-color: var(--border-focus);
+}
+
+.project-avatar:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.project-avatar-count {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 9999px;
+  background: var(--surface-chip);
+  color: var(--text-primary);
+  font-size: 10px;
+  line-height: 16px;
+  text-align: center;
+}
+
+.session-empty-collapsed {
+  color: var(--text-muted);
+  font-size: 11px;
+  text-align: center;
+  padding: 12px 0;
 }
 
 .project-group-header {

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -3300,8 +3300,8 @@ body.is-resizing-column * {
   width: min(440px, calc(100vw - 32px));
   background: var(--bg-modal);
   border: 1px solid var(--border-primary);
-  border-radius: var(--radius-xl);
-  box-shadow: var(--shadow-lg);
+  border-radius: var(--radius-floating);
+  box-shadow: var(--shadow-modal);
 }
 
 .modal-panel.settings-modal {

--- a/apps/desktop/src/styles/themes.css
+++ b/apps/desktop/src/styles/themes.css
@@ -76,6 +76,17 @@ body[data-theme="default-dark"] {
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: 0 8px 24px rgb(0 0 0 / 0.28);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #33332f;
+  --bg-chrome: #1a1a1a;
+  --shadow-soft: 0 1px 2px rgb(0 0 0 / 8%), 0 2px 8px rgb(0 0 0 / 6%);
+  --shadow-strong: 0 1px 2px rgb(0 0 0 / 8%), 0 8px 24px rgb(0 0 0 / 12%);
+  --shadow-modal: 0 1px 2px rgb(0 0 0 / 12%), 0 12px 36px rgb(0 0 0 / 18%);
+  --radius-floating: 16px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }
 
 body[data-theme="default-light"] {
@@ -148,6 +159,17 @@ body[data-theme="default-light"] {
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: 0 8px 24px rgb(0 0 0 / 0.12);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #fbfbf7;
+  --bg-chrome: #ededeb;
+  --shadow-soft: 0 1px 2px rgb(0 0 0 / 4%), 0 2px 8px rgb(0 0 0 / 4%);
+  --shadow-strong: 0 1px 2px rgb(0 0 0 / 5%), 0 8px 24px rgb(0 0 0 / 6%);
+  --shadow-modal: 0 1px 2px rgb(0 0 0 / 8%), 0 12px 36px rgb(0 0 0 / 10%);
+  --radius-floating: 16px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }
 
 /* ---------- Nord (cool arctic blue-gray) ---------- */
@@ -222,6 +244,17 @@ body[data-theme="nord-dark"] {
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: 0 10px 28px rgb(0 0 0 / 0.35);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #383f50;
+  --bg-chrome: var(--bg-app);
+  --shadow-soft: 0 1px 2px rgb(0 0 0 / 8%), 0 2px 8px rgb(0 0 0 / 6%);
+  --shadow-strong: 0 1px 2px rgb(0 0 0 / 8%), 0 8px 24px rgb(0 0 0 / 12%);
+  --shadow-modal: 0 1px 2px rgb(0 0 0 / 12%), 0 12px 36px rgb(0 0 0 / 18%);
+  --radius-floating: 16px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }
 
 body[data-theme="nord-light"] {
@@ -294,6 +327,17 @@ body[data-theme="nord-light"] {
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: 0 10px 28px rgb(46 52 64 / 0.14);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #f5f7fa;
+  --bg-chrome: #e0e3e8;
+  --shadow-soft: 0 1px 2px rgb(46 52 64 / 4%), 0 2px 8px rgb(46 52 64 / 4%);
+  --shadow-strong: 0 1px 2px rgb(46 52 64 / 5%), 0 8px 24px rgb(46 52 64 / 8%);
+  --shadow-modal: 0 1px 2px rgb(46 52 64 / 8%), 0 12px 36px rgb(46 52 64 / 10%);
+  --radius-floating: 16px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }
 
 /* ---------- Tokyo Night (deep blue + saturated accents) ---------- */
@@ -368,6 +412,17 @@ body[data-theme="tokyo-dark"] {
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: 0 8px 28px rgb(0 0 0 / 0.4);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #2f334d;
+  --bg-chrome: var(--bg-app);
+  --shadow-soft: 0 1px 2px rgb(0 0 0 / 12%), 0 2px 8px rgb(0 0 0 / 10%);
+  --shadow-strong: 0 1px 2px rgb(0 0 0 / 12%), 0 8px 24px rgb(0 0 0 / 18%);
+  --shadow-modal: 0 1px 2px rgb(0 0 0 / 16%), 0 12px 36px rgb(0 0 0 / 24%);
+  --radius-floating: 18px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }
 
 body[data-theme="tokyo-light"] {
@@ -440,6 +495,17 @@ body[data-theme="tokyo-light"] {
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: 0 8px 28px rgb(42 43 61 / 0.16);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #f7f7fb;
+  --bg-chrome: #dedfe7;
+  --shadow-soft: 0 1px 2px rgb(42 43 61 / 6%), 0 2px 8px rgb(42 43 61 / 6%);
+  --shadow-strong: 0 1px 2px rgb(42 43 61 / 7%), 0 8px 24px rgb(42 43 61 / 10%);
+  --shadow-modal: 0 1px 2px rgb(42 43 61 / 10%), 0 12px 36px rgb(42 43 61 / 14%);
+  --radius-floating: 18px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }
 
 /* ---------- Warm Paper (cream / ink) ---------- */
@@ -514,6 +580,17 @@ body[data-theme="paper-dark"] {
   --shadow-sm: 0 1px 2px rgb(0 0 0 / 0.2);
   --shadow-md: 0 2px 8px rgb(0 0 0 / 0.22);
   --shadow-lg: 0 12px 32px rgb(0 0 0 / 0.4);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #2a2520;
+  --bg-chrome: var(--bg-app);
+  --shadow-soft: 0 1px 2px rgb(0 0 0 / 0.18), 0 2px 8px rgb(0 0 0 / 0.18);
+  --shadow-strong: 0 1px 2px rgb(0 0 0 / 0.2), 0 8px 24px rgb(0 0 0 / 0.28);
+  --shadow-modal: 0 1px 2px rgb(0 0 0 / 0.24), 0 12px 36px rgb(0 0 0 / 0.34);
+  --radius-floating: 14px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }
 
 body[data-theme="paper-light"] {
@@ -586,6 +663,17 @@ body[data-theme="paper-light"] {
   --shadow-sm: 0 1px 2px rgb(44 36 28 / 0.06);
   --shadow-md: 0 2px 8px rgb(44 36 28 / 0.08);
   --shadow-lg: 0 12px 32px rgb(44 36 28 / 0.14);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #fbf8f2;
+  --bg-chrome: #ebe5d8;
+  --shadow-soft: 0 1px 2px rgb(44 36 28 / 0.05), 0 2px 8px rgb(44 36 28 / 0.06);
+  --shadow-strong: 0 1px 2px rgb(44 36 28 / 0.06), 0 8px 24px rgb(44 36 28 / 0.10);
+  --shadow-modal: 0 1px 2px rgb(44 36 28 / 0.1), 0 12px 36px rgb(44 36 28 / 0.14);
+  --radius-floating: 14px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }
 
 /* ---------- High Contrast (hard edges, max contrast) ---------- */
@@ -660,6 +748,17 @@ body[data-theme="contrast-dark"] {
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: 0 0 0 1px #555555, 0 8px 24px rgb(0 0 0 / 0.6);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #0a0a0a;
+  --bg-chrome: var(--bg-app);
+  --shadow-soft: none;
+  --shadow-strong: none;
+  --shadow-modal: 0 0 0 1px #555555, 0 8px 24px rgb(0 0 0 / 0.6);
+  --radius-floating: 6px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }
 
 body[data-theme="contrast-light"] {
@@ -732,4 +831,15 @@ body[data-theme="contrast-light"] {
   --shadow-sm: none;
   --shadow-md: none;
   --shadow-lg: 0 0 0 1px #000000, 0 8px 24px rgb(0 0 0 / 0.18);
+
+  /* —— Elevation 分层（design system v1.1）—— */
+  --bg-card-elev: #ffffff;
+  --bg-chrome: #f5f5f5;
+  --shadow-soft: none;
+  --shadow-strong: none;
+  --shadow-modal: 0 0 0 1px #000000, 0 8px 24px rgb(0 0 0 / 0.18);
+  --radius-floating: 6px;
+  --radius-card: var(--radius-container);
+  --space-section: 20px;
+  --space-chrome: 12px;
 }


### PR DESCRIPTION
# PR 描述草稿（`feature/ui-elevation-redesign` → `master`）

> 入 git 路径：`apps/desktop/.github/UI_ELEVATION_PR.md`（不参与 release，符合 §2.3 第 10 步的"PR 描述草稿"约定）
> 用法：push 后用 `gh pr create --title "..." --body-file apps/desktop/.github/.github/UI_ELEVATION_PR.md` 一次性灌入 PR

---

## 标题

```
feat(ui): elevation-driven 主次分明改版 (v1.1 设计语言)
```

## Body

```markdown
## 改动类型

- [x] UI / 体验优化（设计语言 v1.1 落地）
- [ ] Bug 修复
- [ ] 新功能
- [ ] 重构
- [ ] 文档
- [ ] 测试 / CI
- [ ] 发版

## 关联 Issue

无独立 issue —— 由用户对"现有 UI 布局太扁平和网格了 / 想要主次分明、简洁直观"的反馈触发，grilling 4 轮对齐决策后实施。

## 变更摘要

原"全窗单 Surface + 1px Board 切边 + 页面内 0 阴影"的扁平网格感，重排为 elevation 驱动的层级式布局。**Composer / 输入区**是整窗唯一主元素；三栏壳层（TopBar / Sidebar / RightPanel）降为低调 chrome；其它 UI 自然下沉到次要。

### 改动范围（10 个原子 commit，squash 后 1 笔）

| 笔 | 主题 | 影响 |
|---|---|---|
| 1 | `design`: 新增 8 个 elevation + spacing token | themes.css / app.css |
| 2 | `docs`: DESIGN.md §一.4 / §五 / §六 / §一附 / §二.1 / §四 / §九 改稿 | DESIGN.md |
| 3 | `feat`: TopBar sticky + 滚动时挂 `--shadow-soft` + 「打开项目」CTA | TopBar / useScrollElevated hook |
| 4 | `feat`: Sidebar 可折叠（56px project avatar 栈） | Sidebar / useNarrowWindow / ClientPrefs 新增 sidebarCollapsed |
| 5 | `feat`: Composer 主卡（圆角 12→16、双层阴影、focus/streaming 升级到 strong） | .composer-shell / mode-pill |
| 6 | `feat`: RightPanel 垂直 nav + Context hero 提为唯一副主卡 | RightPanel / .rp-context-* |
| 7 | `refactor`: chat transcript 行间距 16→20px + 展开态 tool card 提级 | ROW_GAP_PX / .bubble-tool |
| 8 | `refactor`: 设置弹窗圆角 / 阴影与主卡同步 | .modal-panel |
| 9 | `docs`: CHANGELOG Unreleased 写一段 | CHANGELOG.md |

### 设计决策（grilling 4 轮已锁）

- **Q1 → A**：引入温和阴影（双层 `0 1px 2px / 8%, 0 8px 24px / 12%`），突破 DESIGN.md §五"页面内 0 阴影"硬规则；现 §五改为"页面内阴影由 token 控制"。
- **Q2 → A**：Composer / 输入区是唯一"主元素"。
- **Q3 → A**：elevation 配方 = `shadow + 双层 surface（--bg-card-elev）+ 圆角 --radius-floating + 上下 16-20px 呼吸区`。
- **Q4 → B**：三栏壳层全部重排（TopBar 浮起 + Sidebar 重组 + Chat transcript 内部层级 + RightPanel hero 强化），不只是 Composer。

### 主题族策略

本轮只动 `default` 主题。其它 4 主题（nord / tokyo / paper / contrast）在新 token 上各自给"空实现"——

- `nord` / `tokyo`：阴影同 default，圆角 16/18px
- `paper`：阴影最轻一档（4-6%），圆角 14px
- `contrast`：所有阴影 `none` 保持硬边，圆角 6px

10 个主题族 × dark/light 全部补齐 token，无遗漏；下一轮再逐个主题精修。

## 截图

> 截图由 CI e2e 截图回归（Playwright Electron）生成，需要在 PR 通过 CI 后用 `--update-snapshots` 重生 baseline 后附带。
> 本机未跑 e2e（无显示器），无法在此提交截图。

## 测试要点

- [x] **vitest 全套**（49 个）通过：`test-prefs-defaults` / `test-extension-ui` / `test-chat-store` / `test-context-breakdown` / 其余 46 个全绿
- [x] **typecheck**（`apps/desktop` Node + Web 两套）通过
- [x] **commit-msg 钩**（Conventional Commits）通过
- [ ] **e2e 截图回归**（Playwright Electron，4 主题 × 3 状态）需 CI 上跑，失败的 baseline 用 `playwright --update-snapshots` 重生
- [ ] **手动视觉验收**（见下）

### 手动视觉验收清单（review 时过）

- [ ] 深色 / 浅色各看一眼：1 阶提色可见但不过分
- [ ] 4 主题各看一眼：`contrast` 仍 0 阴影、`paper` 阴影最轻
- [ ] 窗口 < 960px：sidebar 不可折叠，右栏隐藏
- [ ] 滚动长 transcript：TopBar 浮起阴影出现，恢复顶部后消失
- [ ] Composer focus → 阴影从 soft 升 strong；blur 后回落
- [ ] sidebar collapse → 展开：chat 区域位置稳定，无 layout shift
- [ ] 设置 → 通用 / 供应商 / 插件 三个页面在主壳层变化后仍正常
- [ ] 主题切换瞬间：所有 elevation token 一次切换，无中间态闪烁
- [ ] WCAG AA 文本对比：Composer 主卡在浅色主题下气泡文字仍 ≥ 4.5:1

## 影响面

- **文件**：`DESIGN.md` + `CHANGELOG.md` + `shared/ipc.ts` + `src/styles/{app,themes}.css` + 8 个组件 + 2 个新 hook
- **新增持久化字段**：`ClientPrefs.sidebarCollapsed?: boolean`（`optional`，旧 prefs 文件无该字段时 fallback `false`）
- **新增 IPC**：无（复用 `prefs.set`）
- **新增依赖**：无
- **API 变更**：无（renderer-only 视觉改版）
- **安全**：无

## 回滚方案

```bash
# 1. 临时禁用新 UI：revert 整笔 PR（squash 后一笔）
git revert <merge-commit-sha>
git push origin master

# 2. 完整回滚（保留分支记录）：
git checkout master
git reset --hard 86faa7c   # 改版前 HEAD
git push --force-with-lease origin master
```

**为什么安全可回滚**：

- 所有 token 改动在 `themes.css` / `app.css` `:root` 段，revert 即恢复旧值
- `ClientPrefs.sidebarCollapsed` 标 `optional`，旧 prefs 文件忽略即可
- 组件层只新增 optional props（`externalStreamRef` / `collapsed`），不破坏 API
- DOM 结构变化局限于 RightPanel 头部 + Sidebar 折叠态；语义 HTML 不变

## CI Checklist

- [x] `desktop`（typecheck + offline test + lint + build）
- [x] `unit-test`（vitest + 覆盖率门槛）
- [ ] `e2e`（Playwright Electron 冒烟 + 截图 baseline 重生）

## 风险登记

- **R1：阴影在浅色 + 小尺寸屏幕上"廉价感"** — 浅色 token 用 4-6% 透明度已规避；paper 主题后调阈值
- **R2：e2e 截图 baseline 大面积重生成** — 待 PR CI 后一次性 review
- **R3：sidebar collapse 引入 layout shift** — CSS `width` 过渡 + `min-width: 56px` 锁底
- **R4：TopBar sticky 与 Electron 标题栏冲突** — 当前 Windows 不需要 macOS 标题栏 padding；保留 hook
- **R5：跨平台字体 hinting** — 1px 边线 + 阴影组合已用 token 避免双层边
```
