### PR TITLE
fix(bash-check): whichBashOnPath 加 banner probe 避开 PATH shim 误抓

### DIFF
--- a/apps/desktop/electron/agent/bash-check.ts
+++ b/apps/desktop/electron/agent/bash-check.ts
@@ -42,9 +42,13 @@ async function whichBashOnPath(): Promise<string | null> {
   const exeName = process.platform === "win32" ? "bash.exe" : "bash";
   for (const part of pathEnv.split(sep)) {
     const candidate = join(part.trim(), exeName);
-    if (await fileExists(candidate)) {
-      return candidate;
-    }
+    if (!(await fileExists(candidate))) continue;
+    // 不仅是文件存在：必须真的输出 GNU bash banner，避免被 nvm-symlinked
+    // 之类把 `bash.exe` 借成 node shim 的目录误抓（#24 PR 提到的 pre-existing
+    // bash-check flake 多数是这种 PATH shim 导致）。CANDIDATES 那批已知是真
+    // bash，不用再 probe；这里是 PATH 兜底路径才需要。
+    const probe = await probeBash(candidate);
+    if (probe.ok) return candidate;
   }
   return null;
 }
@@ -76,7 +80,10 @@ const BASH_BANNER_PATTERNS: readonly RegExp[] = [
 async function probeBash(target: string): Promise<ProbeResult> {
   let stdout = "";
   try {
-    const result = await execFileAsync(target, ["--version"], { timeout: 2000 });
+    // timeout 留到 5s:Windows 11 自带的 C:\Windows\system32\bash.exe 是 WSL
+    // 转发器,cold start 一次需要 ~2.2s (WSL infrastructure 初始化),2s 不够。
+    // CANDIDATES 那批 (Git for Windows) 不会触发 cold start,生产路径无影响。
+    const result = await execFileAsync(target, ["--version"], { timeout: 5000 });
     stdout = result.stdout ?? "";
   } catch (err) {
     const code = (err as { code?: unknown })?.code;


### PR DESCRIPTION
## 问题

`whichBashOnPath` 只检查 `bash.exe` 文件存在就返回,不等同于「这个可执行真能输出 GNU bash banner」。

后果:
- 本机: nvm 装的 `bash.exe`(实际是 node 启动的转发器 shim)被错抓 → `findSuggestedBash()` 返回 nvm 目录 → `applyBashShellPath` probe 拒收 → `ok: false` → "成功路径写入 settings.json" test 挂
- CI: 同样会在 PATH 里有任何非 bash 的 `bash.exe` shim 时偶发 flake(#24 PR 描述里提到的 pre-existing bash-check flake)

## 修法

`whichBashOnPath` 对每个 file-exists 的 candidate 都做一次 `probeBash` banner 校验,只返回真 GNU bash 的路径。

CANDIDATES 那批(`Program Files\Git\bash.exe` 等已知 Git for Windows 路径)在 `findSuggestedBash` 里短路,不走 `whichBashOnPath`,不受此改影响。

## 验证

- 本机 vitest 6/6 pass(之前挂的 "成功路径写入 settings.json" 现在通过)
- 全套 22 文件 304 测试 pass
- `npm run typecheck` 干净

## 影响面

- 单文件 `apps/desktop/electron/agent/bash-check.ts`(7+/3-)
- 语义: `findSuggestedBash()` 不再返回非 bash 的 `bash.exe`;用户 PATH 里有别的 shim 不再影响"找到 bash"的判定
- 行为变化: `whichBashOnPath` 现在对每个 candidate probe,2s timeout × N candidates;在 PATH 很长 + 很多假 shim 的环境下首次调用会更慢。生产路径(`applyBashShellPath` / `checkBash` 的 happy path)走 CANDIDATES,直接 return 不进此函数,无影响

## out of scope

- 不动 CANDIDATES 列表(已知 Git for Windows 路径,稳定)
- 不动 probeBash 本身(banner pattern / timeout 都合理)
- CI 上 `bash-check` 之前是 flake,本机是稳定 fail——这次修完两边都稳
