### PR TITLE
build(ci): node 22 to 24 升级 + fix(bash-check) WSL cold start 配套修

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: apps/desktop/package-lock.json
       - run: npm ci
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: apps/desktop/package-lock.json
       - run: npm ci
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: apps/desktop/package-lock.json
       # 缓存 Playwright 浏览器,避免每次重下

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: "22"
+          node-version: "24"
           cache: npm
           cache-dependency-path: apps/desktop/package-lock.json
 

--- a/apps/desktop/electron/agent/bash-check.ts
+++ b/apps/desktop/electron/agent/bash-check.ts
@@ -42,9 +42,13 @@ async function whichBashOnPath(): Promise<string | null> {
   const exeName = process.platform === "win32" ? "bash.exe" : "bash";
   for (const part of pathEnv.split(sep)) {
     const candidate = join(part.trim(), exeName);
-    if (await fileExists(candidate)) {
-      return candidate;
-    }
+    if (!(await fileExists(candidate))) continue;
+    // 不仅是文件存在：必须真的输出 GNU bash banner，避免被 nvm-symlinked
+    // 之类把 `bash.exe` 借成 node shim 的目录误抓（#24 PR 提到的 pre-existing
+    // bash-check flake 多数是这种 PATH shim 导致）。CANDIDATES 那批已知是真
+    // bash，不用再 probe；这里是 PATH 兜底路径才需要。
+    const probe = await probeBash(candidate);
+    if (probe.ok) return candidate;
   }
   return null;
 }
@@ -76,7 +80,10 @@ const BASH_BANNER_PATTERNS: readonly RegExp[] = [
 async function probeBash(target: string): Promise<ProbeResult> {
   let stdout = "";
   try {
-    const result = await execFileAsync(target, ["--version"], { timeout: 2000 });
+    // timeout 留到 5s:Windows 11 自带的 C:\Windows\system32\bash.exe 是 WSL
+    // 转发器,cold start 一次需要 ~2.2s (WSL infrastructure 初始化),2s 不够。
+    // CANDIDATES 那批 (Git for Windows) 不会触发 cold start,生产路径无影响。
+    const result = await execFileAsync(target, ["--version"], { timeout: 5000 });
     stdout = result.stdout ?? "";
   } catch (err) {
     const code = (err as { code?: unknown })?.code;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "email": "fromlan@qq.com"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "scripts": {
     "desktop:dev": "npm run dev --prefix apps/desktop",


### PR DESCRIPTION
## 概述

两件配套 fix 一起发:

1. **Node 22 → 24 升级**(基础设施工单):跟随 GitHub runner 默认升级(Node 20 已 deprecated,新默认 Node 24);`engines.node` 与 ci.yml / release.yml 的 setup-node 全部从 22 升到 24
2. **bash-check fix**(修 #24 PR 描述的 pre-existing flake + 本地稳定 fail):`whichBashOnPath` 加 banner probe + `probeBash` timeout 2s → 5s

## 为什么一起发

Node 24 升级**会暴露** bash-check 同一条 flake:
- master + Node 22: 1/447 偶发 flake
- master + Node 24: 1/447 **稳定 fail**(本地 24.13.0 已确认)
- 根因是 Windows 11 自带 `C:\Windows\system32\bash.exe`(WSL bash launcher)cold start ~2.2s,大于 probe timeout 2s,被 kill;CI runner 装 Git for Windows 时 CANDIDATES 短路不走 probe 才 PASS

如果不带 fix 一起发,Node 24 升级到 master 后 CI 必然挂。bash-check fix 反过来也建议跟 Node 24 一起验证(本地 + CI 都过才稳)。

## 变更明细

### build(ci): node 22 to 24 升级

- `package.json`:`engines.node` `">=22"` → `">=24"`
- `.github/workflows/ci.yml`:desktop / unit-test / e2e 三个 job 的 `setup-node` `"22"` → `"24"`
- `.github/workflows/release.yml`:release job 的 `setup-node` `"22"` → `"24"`

deps 无变更。本机 Node 24.13.0 已验证:`typecheck` / `lint` 干净,vitest 33 文件 447 测试全过(配合下面 fix)。

### fix(bash-check): whichBashOnPath 加 banner probe + probe timeout 2s → 5s

两个问题表现为同一条 "成功路径写入 settings.json" test 在 Node 24 下稳定 fail:

**问题 1**:`whichBashOnPath` 只检查 `bash.exe` 文件存在就返回,不等同于「真输出 GNU bash banner」。本地 nvm 装的 `bash.exe` shim(实际是 node 启动的转发器)被错抓 → `findSuggestedBash()` 返回 nvm 目录 → `applyBashShellPath` probe 拒收 → `ok:false`。CI 同样在 PATH 里有非 bash 的 `bash.exe` shim 时偶发 flake(#24 PR 描述的 pre-existing bash-check flake 多数是这种 PATH shim 导致)。
- 修法:`whichBashOnPath` 对每个 file-exists 的 candidate 都 probe 一次,只返回真 GNU bash 的路径。CANDIDATES 那批(`Program Files\Git\`)已知真 bash 短路返回,不走此路径。

**问题 2**:`probeBash` timeout 2s 不够 Windows 11 自带 `C:\Windows\system32\bash.exe`(WSL bash launcher)cold start:首次启动要 ~2.2s(WSL infrastructure 初始化),2s timeout 直接被 kill,killed=true → `spawn_failed`。第二次以后 warm 启动只要 ~160ms,但每个 vitest worker 线程独立,每个 test file 第一次 probe 都吃 cold start。
- 修法:`probeBash` timeout `2000ms` → `5000ms`。production 路径(`applyBashShellPath` happy path 走 CANDIDATES)无影响;仅 PATH 兜底 / 用户配 shellPath 验证路径延长最多 3s。

## 验证

- 本机 Node 24.13.0 + 全套 vitest:33 文件 447 测试全过(之前 master 跑 24 是 446/447,挂的就是这条)
- `npm run typecheck` 干净(node + web)
- `npm run lint` 干净
- 离线 tsx 断言链未跑(发版时不强制,CI 会跑)

## 影响面

- 4 文件改动,合计 16+/8-(ci.yml 6,release.yml 2,package.json 2,bash-check.ts 11)
- 行为变化:
  - `findSuggestedBash()` 不再返回非 bash 的 `bash.exe`(PATH 兜底时按 probe-OK 过滤)
  - probe timeout 5s(production happy path 走 CANDIDATES,通常 warm 状态 100-200ms 完成,无感知;PATH 兜底 cold start 最多 5s)
- `engines.node` 升到 24:本机 Node < 24 会触发 npm `EBADENGINE` 警告(不阻断 install)
- GitHub Actions 注释:actions/checkout@4 / setup-node@7 内部默认仍标 Node 20 deprecated 警告(基础设施级,与本仓库无关,留给后续 major 升 v5 时处理)

## 回滚方案

`squash merge` 后 `git revert` 两个 commit,或单独 revert 其中一个:
- 只回退 Node 升级 → revert `c0d7944`,bash-check fix 留下(master 继续在 22 上跑,fix 兼容)
- 只回退 bash-check fix → revert `ae0d716`,Node 24 留下(但 CI 必然挂回,需要同时 revert Node 24)

## out of scope(留作后续)

- actions/checkout@4 / setup-node@7 升 v5(Node 20 deprecated 警告彻底消掉)
- electron-builder / electron 43 是否要跟随 Node 24 同步升(electron 43 已支持 Node 24,本仓库不动)
- dependabot 升 GitHub Actions group(已配 dependabot.yml,本 PR 不动)
