### PR TITLE
release: v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@
 
 ## Unreleased
 
+## 0.5.6
+
+### 改进
+
+- **Node 22 → 24 升级（基础设施）**：跟随 GitHub runner 默认升级（Node 20 已于 2025-09-19 deprecated，新默认 Node 24）。仓库内 `engines.node` 与 `.github/workflows/ci.yml`（desktop / unit-test / e2e 三个 job）+ `.github/workflows/release.yml` 的 `setup-node` 全部从 22 升到 24；本机 Node < 24 启动会触发 `EBADENGINE` 警告（不阻断 install）。CI 上 `actions/checkout@4` / `setup-node@7` 内部仍标 Node 20 deprecated 警告，留后续 major 升 v5 时处理。
+
+### 修复
+
+- **bash-check WSL cold start + PATH shim 误抓**：`whichBashOnPath` 对每个 file-exists 的 `bash.exe` candidate 做 banner probe，只返回真 GNU bash 的路径——之前只检查文件存在，本机 nvm 装的 `bash.exe` shim（实际是 node 启动的转发器）会被错抓为 bash 候选（#24 PR 描述的 pre-existing bash-check flake 多数由此类 PATH shim 导致）。同时 `probeBash` timeout 从 2s 升到 5s——Windows 11 自带 `C:\Windows\system32\bash.exe`（WSL bash launcher）首次启动要 ~2.2s（WSL infrastructure 初始化），2s timeout 在 Node 24 runner 上会被 kill 导致 `spawn_failed`，CI 升 Node 24 后稳定暴露此问题。production 路径（`applyBashShellPath` happy path 走 CANDIDATES 已知 Git for Windows 路径）不受影响。
+
 ## 0.5.5
 
 ### 改进

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x-agent-desktop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x-agent-desktop",
-      "version": "0.5.5",
+      "version": "0.5.6",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.2",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-agent-desktop",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Pi Agent desktop client (X-agent)",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
## 概述

0.5.6 patch 发版：Node 22→24 基础设施升级 + bash-check 修 WSL cold start 与 PATH shim 误抓。

## 变更摘要

- **改进**：Node 22 → 24 升级（`engines.node` 与 ci.yml / release.yml 的 setup-node），跟随 GitHub runner 默认升级
- **修复**：`whichBashOnPath` 加 banner probe（避免 nvm shim / 非 bash 的 `bash.exe` 被错抓）+ `probeBash` timeout 2s → 5s（WSL bash cold start 留余量）

## 版本

`apps/desktop/package.json` 0.5.5 → 0.5.6

## 测试

- `npm run lint` 待 CI 验证
- `npm run test:unit` 待 CI 验证（在 Node 24 下 33 文件 447 vitest 全过，本机已预验证）
- `npm run test:e2e` 待 CI 验证

## 影响面

- build 改动，向后兼容（仅升级 Node，无 API 变更）
- `engines.node` 升到 24：本机 Node < 24 启动会触发 `EBADENGINE` 警告（不阻断 install）
- 行为变化：`findSuggestedBash()` 不再返回非 bash 的 `bash.exe`；PATH 兜底路径 probe 延长最多 5s（production happy path 走 CANDIDATES 已知 Git for Windows 路径，warm 状态 100-200ms 完成，无感知）

## 回滚方案

`git revert` release commit 后重新打 tag；或单独 revert 对应 fix commit 留 Node 24 升级。
