### PR TITLE
fix(thinking): Composer SelectMenu 仅展示模型支持的级别, 消除 Pi 静默 clamp

### DIFF
--- a/apps/desktop/electron/agent/session-host.ts
+++ b/apps/desktop/electron/agent/session-host.ts
@@ -354,7 +354,18 @@ export class SessionHost {
         this.textDeltaCount = 0;
         this.thinkingDeltaCount = 0;
       }
-      dbgLog("emit", "->", event.type);
+      // DEBUG(thinking-switch #30): 详细 payload for 排查 thinking 切换失联。
+      // 只在 3 个关键事件上多打一条 — session_info / session_mode / notice
+      // 任何 status 错误，避免淹没常规流。
+      if (
+        event.type === "session_info" ||
+        event.type === "session_mode" ||
+        event.type === "notice"
+      ) {
+        dbgLog("emit", "->", event.type, event);
+      } else {
+        dbgLog("emit", "->", event.type);
+      }
     }
     const win = this.getWindow();
     if (win && !win.isDestroyed()) {
@@ -880,11 +891,14 @@ export class SessionHost {
     id: string,
   ): Promise<{ ok: boolean; error?: string }> {
     if (!this.bundle) return { ok: false, error: "尚未打开项目" };
+    // DEBUG(thinking-switch #30): 跟踪 setModel 调用链,排查周期 session_info
+    dbgLog("setModel", "in", { provider, id });
     try {
       const runtime = await this.ensureRuntime();
       const model = runtime.getModel(provider, id);
       if (!model) {
         const error = `未找到模型 ${provider}/${id}`;
+        dbgLog("setModel", "model-not-found", { provider, id });
         this.emitReplaceableNotice("model", error, "error");
         return { ok: false, error };
       }
@@ -897,6 +911,7 @@ export class SessionHost {
         cwd: this.bundle.cwd,
         model: modelFromSession(this.bundle.session),
         thinkingLevel: this.bundle.session.thinkingLevel as ThinkingLevel,
+        availableThinkingLevels: this.bundle.session.getAvailableThinkingLevels(),
         sessionPath: this.bundle.sessionPath,
       });
       this.emitUsageUpdate();
@@ -919,11 +934,28 @@ export class SessionHost {
   async setThinkingLevel(
     level: ThinkingLevel,
   ): Promise<{ ok: boolean; thinkingLevel?: ThinkingLevel }> {
-    if (!this.bundle) return { ok: false };
+    if (!this.bundle) {
+      dbgLog("setThinkingLevel", "no-bundle", { level });
+      return { ok: false };
+    }
+    // DEBUG(thinking-switch #30): 跟踪 thinking 切换入参,排查"调了但 UI 没动"
+    const currentBefore = this.bundle.session.thinkingLevel;
+    dbgLog("setThinkingLevel", "in", {
+      requested: level,
+      currentBefore,
+      available: this.bundle.session.getAvailableThinkingLevels(),
+    });
     this.bundle.session.setThinkingLevel(level);
     // Persist the model-clamped effective level so prefs / TopBar / Settings stay
     // aligned (e.g. DeepSeek V4 maps medium→high; unsupported → nearest).
     const effective = this.bundle.session.thinkingLevel as ThinkingLevel;
+    dbgLog("setThinkingLevel", "after-set", {
+      requested: level,
+      effective,
+      changedVsBefore: effective !== currentBefore,
+      // 标记 Pi 是否把目标级别钳制了(available levels 不含) — 切换被静默回弹的根因
+      clamped: effective !== level,
+    });
     // Await the persist: renderer follows this IPC with `prefs.get()`, and a
     // fire-and-forget write can leave a stale cache that clobbers the effective
     // level it just received via session_info (composer snap-back bug).
@@ -934,6 +966,7 @@ export class SessionHost {
       cwd: this.bundle.cwd,
       model: modelFromSession(this.bundle.session),
       thinkingLevel: effective,
+      availableThinkingLevels: this.bundle.session.getAvailableThinkingLevels(),
       sessionPath: this.bundle.sessionPath,
     });
     return { ok: true, thinkingLevel: effective };
@@ -1032,6 +1065,9 @@ export class SessionHost {
       thinkingLevel:
         (this.bundle?.session.thinkingLevel as ThinkingLevel) ??
         getCachedPrefs().thinkingLevel,
+      availableThinkingLevels: this.bundle
+        ? this.bundle.session.getAvailableThinkingLevels()
+        : undefined,
       error: this.lastError,
       hasSession: Boolean(this.bundle),
     };

--- a/apps/desktop/electron/agent/session-lifecycle.ts
+++ b/apps/desktop/electron/agent/session-lifecycle.ts
@@ -34,6 +34,7 @@ import { getXAgentSessionsRoot, isXAgentSessionPath } from "./session-paths";
 import { displaySessionName } from "./session-title";
 import type { GodotRpcBridge } from "./godot-rpc-bridge";
 import { createGodotTools } from "./godot-tools";
+import { dbgLog } from "../../shared/debug-log";
 import {
   createDesktopExtensionUi,
   mapExtensionNotifyLevel,
@@ -390,7 +391,14 @@ export class SessionLifecycle {
       model: info.model,
       thinkingLevel: info.thinkingLevel,
       sessionType: requestedType,
+      availableThinkingLevels: session.getAvailableThinkingLevels(),
       sessionPath,
+    });
+    // DEBUG(thinking-switch #30): 标记 openSession 的 session_info
+    dbgLog("lifecycle", "session_info (openSession)", {
+      sessionId: session.sessionId,
+      thinkingLevel: info.thinkingLevel,
+      available: session.getAvailableThinkingLevels(),
     });
     this.a().setLastHistoryFingerprint(this.a().historyFingerprint(history));
     this.a().emit({ type: "history_replace", items: history });
@@ -655,12 +663,18 @@ export class SessionLifecycle {
     void patchPrefs(patch);
     this.a().setLastHistoryFingerprint(this.a().historyFingerprint([]));
     this.a().emit({ type: "history_replace", items: [] });
+    // DEBUG(thinking-switch #30): 标记 closeWorkspace 的 session_info
+    dbgLog("lifecycle", "session_info (closeWorkspace)", {
+      thinkingLevel: getCachedPrefs().thinkingLevel,
+    });
     this.a().emit({
       type: "session_info",
       sessionId: "",
       cwd: "",
       model: null,
       thinkingLevel: getCachedPrefs().thinkingLevel,
+      // close 时没有 bundle 上下文, renderer 拿到 undefined 时回退到全部 THINKING_LEVELS
+      availableThinkingLevels: [],
       sessionPath: null,
     });
     this.a().setStatus("idle");

--- a/apps/desktop/electron/agent/session-mode/controller.ts
+++ b/apps/desktop/electron/agent/session-mode/controller.ts
@@ -54,6 +54,7 @@ import {
   buildGoalModeSystemAppend,
   buildPlanModeSystemAppend,
 } from "../../../shared/mode-prompt";
+import { dbgLog } from "../../../shared/debug-log";
 
 export type SessionModeHost = {
   getBundle(): {
@@ -308,6 +309,8 @@ export class SessionModeController {
     if (mode !== "agent" && mode !== "ask" && mode !== "plan" && mode !== "goal") {
       return { ok: false, error: `非法 mode：${String(mode)}` };
     }
+    // DEBUG(thinking-switch #30): 跟踪 setMode 入口,排查 模式切换后 thinking 被静默重置
+    dbgLog("mode", "setMode in", { from: this.agentMode, to: mode });
     const bundle = this.host().getBundle();
     if (!bundle) {
       return { ok: false, error: "尚未打开项目" };

--- a/apps/desktop/electron/ipc/register-session-config-ipc.ts
+++ b/apps/desktop/electron/ipc/register-session-config-ipc.ts
@@ -3,18 +3,23 @@ import type { SessionHost } from "../agent/session-host";
 import type { ThinkingLevel } from "../../shared/ipc";
 import { IPC_CHANNELS } from "../../shared/ipc-channels";
 import { handle } from "./register-ipc";
+import { dbgLog } from "../../shared/debug-log";
 
 /** Session tuning / usage / resources IPC — thin forwards to SessionHost. */
 export function registerSessionConfigIpc(
   ipcMain: IpcMain,
   sessionHost: SessionHost,
 ): void {
-  handle(ipcMain, IPC_CHANNELS.setModel, async (_e, provider: string, id: string) =>
-    sessionHost.setModel(provider, id),
-  );
-  handle(ipcMain, IPC_CHANNELS.setThinkingLevel, async (_e, level: ThinkingLevel) =>
-    sessionHost.setThinkingLevel(level),
-  );
+  handle(ipcMain, IPC_CHANNELS.setModel, async (_e, provider: string, id: string) => {
+    // DEBUG(thinking-switch #30): IPC 入口,确认 renderer 实际下发到主进程
+    dbgLog("ipc", "setModel invoke", { provider, id });
+    return sessionHost.setModel(provider, id);
+  });
+  handle(ipcMain, IPC_CHANNELS.setThinkingLevel, async (_e, level: ThinkingLevel) => {
+    // DEBUG(thinking-switch #30): IPC 入口,确认 composer 点选确实到达主进程
+    dbgLog("ipc", "setThinkingLevel invoke", { level });
+    return sessionHost.setThinkingLevel(level);
+  });
   handle(ipcMain, IPC_CHANNELS.listModels, async () => sessionHost.listModels());
   handle(ipcMain, IPC_CHANNELS.getToolDetail, async (_e, toolCallId: string) =>
     sessionHost.getToolDetail(toolCallId),

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -765,6 +765,12 @@ export type UiAgentEvent =
       thinkingLevel: ThinkingLevel;
       /** Active session type (locked at creation). */
       sessionType?: SessionType;
+      /**
+       * Thinking levels the current model actually supports (Pi `getAvailableThinkingLevels`).
+       * Renderer uses this to filter the SelectMenu so users don't pick a level that
+       * Pi will silently clamp back to `off` (issue #30: thinking 切换被静默回弹).
+       */
+      availableThinkingLevels: ThinkingLevel[];
       sessionPath?: string | null;
     }
   | {
@@ -819,6 +825,10 @@ export interface HostStatus {
   sessionPath: string | null;
   model: ModelInfo | null;
   thinkingLevel: ThinkingLevel;
+  /** See {@link UiAgentEvent} session_info — for the renderer to filter the
+   *  Composer thinking SelectMenu. Falls back to all THINKING_LEVELS when the
+   *  bundle is missing (no project open). */
+  availableThinkingLevels?: ThinkingLevel[];
   error?: string;
   hasSession: boolean;
 }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -98,6 +98,11 @@ export default function App() {
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [sessionsLoaded, setSessionsLoaded] = useState(false);
   const [prefs, setPrefs] = useState<ClientPrefs | null>(null);
+  // 渲染端：当前 session 模型支持的 thinking 级别。
+  // null = 还没拿到（尚未打开项目），fallback 到全部 THINKING_LEVELS。
+  // 见 issue #30：Pi 会把不支持的级别静默 clamp，UI 过滤掉让用户能看到实际可选。
+  const [availableThinkingLevels, setAvailableThinkingLevels] =
+    useState<ThinkingLevel[] | null>(null);
   const [bash, setBash] = useState<BashCheckResult | null>(null);
   const [git, setGit] = useState<GitCheckResult | null>(null);
   const [auth, setAuth] = useState<AuthStatus | null>(null);
@@ -256,6 +261,7 @@ export default function App() {
     setConfirmState,
     setFollowNonce,
     setPrefs,
+    setAvailableThinkingLevels,
     setPrefsRecovery,
     setSecretCodec,
     setBash,
@@ -296,6 +302,7 @@ export default function App() {
     sessionIdRef,
     usageFetchGen,
     setPrefs,
+    setAvailableThinkingLevels,
     setQueuedSteering,
     setEditingEntryId,
     setItems,
@@ -570,8 +577,11 @@ export default function App() {
   };
 
   const onThinkingChange = async (level: ThinkingLevel) => {
+    // DEBUG(thinking-switch #30): 渲染端入口,确认 composer 点选确实触发 IPC
+    dbgLog("renderer", "onThinkingChange click", { level });
     const result = await window.xAgent.session.setThinkingLevel(level);
     if (!result.ok) {
+      dbgLog("renderer", "onThinkingChange !ok", { level, result });
       setError("切换 Thinking 失败（请先打开项目）");
       return;
     }
@@ -579,6 +589,7 @@ export default function App() {
     // racy `prefs.get()` round trip: the prefs cache can lag the session apply
     // and would snap the composer select back to the stale level.
     const effective = result.thinkingLevel ?? level;
+    dbgLog("renderer", "onThinkingChange ok", { level, effective, result });
     setPrefs((prev) =>
       prev ? { ...prev, thinkingLevel: effective } : prev,
     );
@@ -1188,7 +1199,10 @@ export default function App() {
           models={models}
           currentModelKey={currentModelKey}
           thinkingLevel={prefs?.thinkingLevel ?? "high"}
-          thinkingLevels={THINKING_LEVELS}
+          thinkingLevels={
+            // issue #30: 只暴露模型实际支持的级别,避免 Pi 静默 clamp 后回弹
+            availableThinkingLevels ?? THINKING_LEVELS
+          }
           onModelChange={onModelChange}
           onThinkingChange={onThinkingChange}
           onToggleThinking={toggleThinking}

--- a/apps/desktop/src/components/ChatPanel.tsx
+++ b/apps/desktop/src/components/ChatPanel.tsx
@@ -14,6 +14,7 @@ import { ChatTranscript } from "./ChatTranscript";
 import { SlashMenu } from "./SlashMenu";
 import { AtMenu } from "./AtMenu";
 import { SelectMenu } from "./SelectMenu";
+import { dbgLog } from "@shared/debug-log";
 import {
   Bot,
   Brain,
@@ -571,9 +572,14 @@ function ChatPanelImpl(props: Props) {
                   className="select-menu-compact select-menu-centered"
                   value={props.thinkingLevel}
                   options={thinkingOptions}
-                  onChange={(v) =>
-                    props.onThinkingChange(v as ThinkingLevel)
-                  }
+                  onChange={(v) => {
+                    // DEBUG(thinking-switch #30): 渲染端 SelectMenu 选值时打点
+                    dbgLog("renderer", "thinking SelectMenu onChange", {
+                      picked: v,
+                      currentValue: props.thinkingLevel,
+                    });
+                    props.onThinkingChange(v as ThinkingLevel);
+                  }}
                   disabled={thinkingDisabled}
                   aria-label="Thinking"
                 />

--- a/apps/desktop/src/hooks/useAgentEventRouter.ts
+++ b/apps/desktop/src/hooks/useAgentEventRouter.ts
@@ -9,6 +9,7 @@ import type {
   AgentStatus,
   ClientPrefs,
   GoalInfo,
+  ThinkingLevel,
   UiAgentEvent,
 } from "@shared/ipc";
 import type { SessionType } from "@shared/session-type";
@@ -39,6 +40,13 @@ type EventRouterDeps = {
   sessionIdRef: MutableRefObject<string | null>;
   usageFetchGen: MutableRefObject<number>;
   setPrefs: Dispatch<SetStateAction<ClientPrefs | null>>;
+  /**
+   * Thinking levels supported by the current session's model. Driven by
+   * `session_info` events (Pi `getAvailableThinkingLevels()`). `null` while
+   * no session is open — Composer falls back to all THINKING_LEVELS.
+   * See issue #30.
+   */
+  setAvailableThinkingLevels: Dispatch<SetStateAction<ThinkingLevel[] | null>>;
   setQueuedSteering: Dispatch<SetStateAction<string[]>>;
   setEditingEntryId: Dispatch<SetStateAction<string | null>>;
   setItems: Dispatch<SetStateAction<ChatItem[]>>;
@@ -64,6 +72,7 @@ export function useAgentEventRouter(deps: EventRouterDeps): void {
     sessionIdRef,
     usageFetchGen,
     setPrefs,
+    setAvailableThinkingLevels,
     setQueuedSteering,
     setEditingEntryId,
     setItems,
@@ -112,6 +121,13 @@ export function useAgentEventRouter(deps: EventRouterDeps): void {
         return;
       }
       if (event.type === "session_info") {
+        // DEBUG(thinking-switch #30): 渲染端确认收到 session_info 时的 thinkingLevel
+        dbgLog("renderer", "session_info received", {
+          thinkingLevel: event.thinkingLevel,
+          availableThinkingLevels: event.availableThinkingLevels,
+          model: event.model,
+          sessionId: event.sessionId,
+        });
         const nextId = event.sessionId || null;
         const prevId = sessionIdRef.current;
         setCwd(event.cwd || null);
@@ -129,6 +145,14 @@ export function useAgentEventRouter(deps: EventRouterDeps): void {
           // 新会话补发 queue_update([])，banner 会显示过期内容）。
           setQueuedSteering([]);
         }
+        // Sync the model-supported thinking levels (used by the Composer
+        // SelectMenu to avoid offering levels Pi would silently clamp — #30).
+        // closeWorkspace emits []; treat that as "no session → fall back to all".
+        setAvailableThinkingLevels(
+          event.availableThinkingLevels.length > 0
+            ? event.availableThinkingLevels
+            : null,
+        );
         setPrefs((prev) =>
           prev
             ? {

--- a/apps/desktop/src/hooks/useWorkspaceSession.ts
+++ b/apps/desktop/src/hooks/useWorkspaceSession.ts
@@ -55,6 +55,7 @@ export type UseWorkspaceSessionOpts = {
   setConfirmState: Dispatch<SetStateAction<RetractConfirmState>>;
   setFollowNonce: Dispatch<SetStateAction<number>>;
   setPrefs: Dispatch<SetStateAction<ClientPrefs | null>>;
+  setAvailableThinkingLevels: Dispatch<SetStateAction<ThinkingLevel[] | null>>;
   setPrefsRecovery: Dispatch<SetStateAction<PrefsRecoveryNotice | null>>;
   setSecretCodec: Dispatch<SetStateAction<SecretCodecStatus | null>>;
   setBash: Dispatch<SetStateAction<BashCheckResult | null>>;
@@ -86,6 +87,7 @@ export function useWorkspaceSession(opts: UseWorkspaceSessionOpts) {
     setConfirmState,
     setFollowNonce,
     setPrefs,
+    setAvailableThinkingLevels,
     setPrefsRecovery,
     setSecretCodec,
     setBash,
@@ -146,6 +148,12 @@ export function useWorkspaceSession(opts: UseWorkspaceSessionOpts) {
           : prev,
       );
     }
+    // Sync the model-supported thinking levels (issue #30).
+    setAvailableThinkingLevels(
+      s.availableThinkingLevels && s.availableThinkingLevels.length > 0
+        ? s.availableThinkingLevels
+        : null,
+    );
   }, [
     fetchSessionUsage,
     sessionIdRef,
@@ -156,6 +164,7 @@ export function useWorkspaceSession(opts: UseWorkspaceSessionOpts) {
     setError,
     setItems,
     setPrefs,
+    setAvailableThinkingLevels,
     setQueuedSteering,
     setSessionId,
     setStatus,


### PR DESCRIPTION
## Summary

Composer Thinking SelectMenu 之前把 `THINKING_LEVELS`（`off / minimal / low / medium / high / max`）全部铺出来，但 Pi SDK `setThinkingLevel` 会按 `session.getAvailableThinkingLevels()` 把不支持的级别**静默 clamp** 到最近的合法值（典型 `off`），随后 `session_info` 回写 `thinkingLevel=clamp 结果`，Composer 看似"切换失败"。

复现：在 `minimax/MiniMax-M3`（仅支持 `off`）上点 Composer 的 `Thinking → High` 下拉 → UI 回弹到 `off`，主进程日志：

```text
[setThinkingLevel] in      { requested: 'high', currentBefore: 'off', available: ['off'] }
[setThinkingLevel] after-set { requested: 'high', effective: 'off', clamped: true, changedVsBefore: false }
```

## Fix

把 `availableThinkingLevels`（来自 Pi `getAvailableThinkingLevels()`）沿 `SessionInfo` / `HostStatus` 透传到渲染端，Composer SelectMenu 用它过滤——只展示模型真正支持的级别。Settings → 默认 Thinking 故意保留全级别（它是未来会话的偏好，跨模型适用）。

## Test plan

- [ ] 当前 `minimax/MiniMax-M3` 模型下，Composer Thinking 下拉应**只显示 `Off` 一项**
- [ ] 切换到支持 thinking 的模型（anthropic），下拉应**自动扩展**出多档
- [ ] 切回 `minimax/MiniMax-M3`，下拉**自动回缩**到 `['off']`
- [ ] Settings → 默认 Thinking 仍展示全 6 档（用户偏好可以预设，未来切到支持模型时生效）
- [ ] 在支持 thinking 的模型上切换 Composer Thinking → `session_info` 中 `thinkingLevel` 与 `prefs.thinkingLevel` 同步更新
- [ ] 在不支持 thinking 的模型上：原 `high` 偏好降级到 `off` 时有可见反馈（状态栏 / 旧条目里看到），而不是无声

## Linked issue

Closes #30

## Checklist

- [x] Conventional Commits commit message
- [x] 不升版本（按维护者要求）
- [x] typecheck 通过
- [x] 关键 vitest 套件（session-host-helpers / session-mode-controller / session-mode-smoke / session-event-bridge-stale）通过
- [ ] CI 三 job 全绿（`desktop` / `unit-test` / `e2e`）
- [ ] 至少 1 approve
- [ ] squash merge 回 master
