### PR TITLE
docs(readme): 重写 README（Hero / 三段叙事 / 0.5.x 同步）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -2,144 +2,189 @@
 
 [中文](README.md) · [English](README.en.md)
 
-A desktop coding agent for **Godot 4**, built on [Pi](https://pi.dev).
+[![Version](https://img.shields.io/badge/version-0.5.5-blue)](apps/desktop/package.json)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Platform: Windows](https://img.shields.io/badge/platform-Windows%2010%2F11-blueviolet)](#requirements)
+[![Godot: 4.x](https://img.shields.io/badge/Godot-4.x-478cbf)](#requirements)
 
-Edit scenes and scripts in your project, drive the editor over RPC (reload / run / import), and search official docs offline—in one session. Version: see [`apps/desktop/package.json`](apps/desktop/package.json).
+**A desktop coding agent for Godot 4**—edit scenes, modify scripts, run the scene, roll back: **all in one session**.
 
-## Positioning
+Not a chat UI shell. Not a VS Code replacement. A **long-horizon coding agent**: Shadow Git rollback, hard mode gates, Thinking levels, branded client.
+
+![X-agent main window](docs/screenshots/main-window.png)
+
+> The desktop UI is currently **Chinese-only**. This English README documents the product; an in-app locale switch is not shipped yet.
+
+## Table of contents
+
+- [30-second start](#30-second-start)
+- [What do you want to do with X-agent?](#what-do-you-want-to-do-with-x-agent)
+- [Key capabilities](#key-capabilities)
+- [Should I use X-agent?](#should-i-use-x-agent)
+- [Three concepts you must know](#three-concepts-you-must-know)
+- [Keyboard shortcuts](#keyboard-shortcuts)
+- [Settings](#settings)
+- [Data locations](#data-locations)
+- [Updates & installation](#updates--installation)
+- [Security & privacy](#security--privacy)
+- [FAQ](#faq)
+- [Feedback & contributing](#feedback--contributing)
+- [Credits](#credits)
+- [Contact](#contact)
+
+## 30-second start
+
+1. **Download**: install the Windows package from [Releases](https://github.com/Fromlan/X-agent/releases/latest)
+2. **Open project**: pick your Godot project root (auto-resumes the latest session)
+3. **Authenticate**: Settings → General → "Open Pi login" (or `pi login` already signed in locally)
+4. **(Optional) Godot editor bridge**: Settings → Godot → Editor connection → install the **X-agent RPC** addon
+5. Type a prompt, press Enter
+
+**Going deeper**: four role-based scenarios below.
+
+## What do you want to do with X-agent?
+
+### 🎮 Godot developer · edit code + run scene
+Open project → Agent mode → pick model → ask "add a dash to `Player.gd` and run the current scene" → Agent edits the file, editor RPC reloads, runs the scene, error messages stream back—**all in the same session**.
+
+### ✍️ Solo game designer · write design docs (keep `game/` clean)
+Pick **design session type** when creating a session → writes are hard-confined to `<cwd>/game-design/` → 5 preinstalled design skills help with project initiation / numbers / core loop → UI flips to a warm theme to distinguish from code sessions.
+
+### 🔬 Read-only research · ask API, look up docs
+Switch to **Ask mode** → tool allowlist hard-closes `write` / `edit` → `bash` only allows read-only commands and paths must stay inside the project cwd → perfect for "find out how GDScript singletons work before I touch the code".
+
+### 🎯 Goal-driven · let the agent run until the goal is met
+Switch to **Goal mode** → set a completion condition (e.g. "add combo counter to `ScoreManager.gd` + show on HUD") → evaluator auto-continues while the goal is unmet (turn + token double budget).
+
+## Key capabilities
 
 | | |
 |---|---|
-| What it is | A Godot-focused coding agent (Electron desktop client) |
-| What it is not | A general-purpose multi-language IDE; Godot is not “just another plugin” |
-| Surface | Project files + Godot editor control plane + official docs search |
-| Runtime | Reuses Pi auth/models; sessions isolated from Pi CLI |
+| **🎯 Design sessions** | Writes hard-confined to `<cwd>/game-design/`, warm theme UI. 5 preinstalled skills: `design-initiation` / `design-process` / `design-systems` / `design-numerical` / `design-core-loop` |
+| **🎮 Godot integration** | Editor RPC (port 8765, fallback 8765–8774); 17 tools spanning scene introspection / debugger / resource hygiene / export / config R/W / read-only introspection |
+| **📜 godot-docs-4-7** | Engine-conventions skill (auto-discovered by Pi); load SKILL.md on demand via `read`—**0 tokens wasted on methodology you don't need** |
+| **↩️ Shadow Git rollback** | Per-turn checkpoints isolated from your `.git`; restores by diff path (won't clobber edits you made during the turn) |
+| **🔀 4 modes + 2 types** | Mutually exclusive modes: Agent / Ask / Plan / Goal; `code` / `design` session types (orthogonal to mode) |
+| **⚡ Diff display** | Inspect `+/-`-colored diffs before retracting (with file count and `+N` / `-N` stats) |
+| **🎨 8 built-in logos + custom upload** | Settings → General → Brand: Neon Cyber / Lava Burn / Plasma Thunder / Holographic Rainbow / Rose Gold Metallic / Pixel 8-bit / Glitch / Cosmic Nebula |
+| **🧠 Thinking levels + thinking-orbs** | Auto-clamp Thinking for models like DeepSeek; particle-orbit animation while running, not a spinner |
+| **🎨 v1.1 design language** | Elevation-driven hierarchy: the Composer is the single main element; chrome (TopBar / Sidebar / RightPanel) steps back; 10 theme families (default / nord / tokyo / paper / contrast × dark/light) |
 
-## Features
+## Should I use X-agent?
 
-### Godot
-
-- **Editor RPC** — open/reload scenes, run current or main scene, reimport resources, multi-editor routing, play-error capture; default port `8765` (fallback `8765–8774`)
-- **Official docs** — offline search after importing doc sources or a zip (enable in Tools)
-- **Godot Pi package** — domain skills/prompts (one-click install in Settings → Plugins)
-- **Right panel Godot** — bridge status and shortcuts
-- **Ready checklist** — guided setup for auth / bash·Git / RPC addon / Godot tools / docs; optional “don’t remind again”
-
-### Agent & sessions
-
-- **Chat** — open a project, resume sessions, steer/abort while streaming; Thinking; `@path` file refs (shown as expandable chips after send)
-- **Session modes** — mutually exclusive **Agent | Plan | Goal** in the composer
-  - **Agent** — normal coding within the tool allowlist
-  - **Plan** — read-only research + `write_plan`; editable plan in the right panel / save to workspace; **Build plan** switches back to Agent to implement; hard `tool_call` gate against writes
-  - **Goal** — set a completion condition; independent evaluator auto-continues until met
-- **Sessions** — grouped by project; restore/rename/delete; auto titles; hide projects from the sidebar
-- **Turn edits** — rewind, edit-resend, regenerate; Shadow Git checkpoints restore the workspace (separate from the user `.git`); without Git, falls back to `write`/`edit` baselines; confirm dialog with risk hints
-- **Skill cards** — `read` of a `SKILL.md` shows as a “Skill · name” card
-- **Right panel** — context breakdown & compact, **Plan**, tool details, project file tree (Markdown preview), Godot status
-
-### Config & ops
-
-- **Providers** — profiles, model list fetch; import Pi / cc-switch configs; Thinking level clamp/fix for models like DeepSeek
-- **Plugins** — prompts, skills, extensions, themes, packages
-- **Tool allowlist** — built-in I/O & shell on by default; Godot editor/docs tools off until enabled; **read-only safe profile** turns off bash/write/edit
-- **Usage** — local usage summary (Settings → Usage)
-- **Auth** — in-app Pi login guidance
-- **Theme** — dark default / light; toggle in Settings and the top bar
-- **Updates** — packaged builds silently check GitHub Releases (no auto-download); in-app prompt + TopBar entry to download / install; Settings and **Open Releases** fallback
-
-## Requirements
-
-- Windows (installer currently shipping)
-- A Godot **4.x** project (when using the editor control plane)
-- Node.js 24+ (for building from source)
-- Model auth (any of):
-  - **Settings → Providers** — create and enable a profile
-  - **Settings → General** → Open Pi login
-  - Local [Pi CLI](https://pi.dev) already signed in
-- Shell tools: [Git for Windows](https://git-scm.com/download/win) recommended, or set bash path (`shellPath`) in Settings
-
-## Usage
-
-1. Open the app → **Open project** to your Godot project root (resumes the latest session by default)
-2. Pick model & Thinking from the toolbar below the input; switch **Agent / Plan / Goal** as needed; send prompts
-3. For the Godot control plane:
-   - Enable Godot editor / docs tools under **Settings → Tools**
-   - **Settings → Godot → Editor**: install/enable the **X-agent RPC** addon and keep the bridge connected
-   - (Optional) one-click install the Godot Pi package under **Settings → Plugins**; import doc sources under **Settings → Godot → Official docs**
-4. Manage history on the left; context, plan, tools, files, and Godot status on the right
-5. Plan flow: switch to Plan → describe the task → agent researches and writes a plan → review/edit in the right panel → **Build plan**
-
-| Settings | Contents |
+| Your situation | Recommendation |
 |---|---|
-| General | Theme, default Thinking, bash, Pi login, auto-update |
-| Providers | Provider profiles and import |
-| Usage | Local usage summary |
-| Tools | Tool allowlist, group toggles, read-only safe profile |
-| Plugins | Prompts / skills / extensions / themes / Packages |
-| Godot | **Editor connection** · **Official docs** |
+| Building a Godot 4 project, **Windows** | ✅ Install it |
+| Building a Godot 4 project, **macOS / Linux** | ⏸ Wait for macOS / Linux installers ([ROADMAP 3.4](docs/roadmap.md)) |
+| Using Unity / Unreal / general coding | ❌ Not a fit (Godot-specialized) |
+| Just want to try LLM chat | ❌ Use [Pi CLI](https://pi.dev) directly—lighter |
+| Need cloud / real-time collaboration | ❌ Local desktop, single-maintainer project |
+
+## Three concepts you must know
+
+- **Session mode** (mutually exclusive): Agent / Ask / Plan / Goal—decides **which tools are available**
+- **Session type** (orthogonal): `code` (default) / `design`—decides the **scope of writes**
+- **Rollback source**: Shadow Git checkpoints (isolated from your `.git`); restores by diff path
+
+## Keyboard shortcuts
+
+| Shortcut | Action |
+|---|---|
+| `Shift+Tab` | Cycle through modes |
+| `F12` / `Ctrl+Shift+I` | DevTools (requires `--x-agent-debug` / `X_AGENT_DEBUG=1`) |
+| `Esc` | Close the current modal |
+| `Ctrl+,` | Open Settings |
+| `Ctrl+Enter` | Send message (when input is multiline) |
+
+## Settings
+
+| Section | Contents |
+|---|---|
+| General | Theme, default Thinking, bash path, Pi login, auto-update, **Brand (logo selector)** |
+| Providers | Model profiles, import Pi / cc-switch configs, Thinking clamp |
+| Usage | Local per-day / per-model usage summary |
+| Tools | Built-in / Godot editor / Godot docs tool allowlist; active in Agent / Goal modes |
+| Plugins | Prompts / Skills / Extensions / Themes / Packages (Pi's five kinds) |
+| Godot | **Editor connection** (RPC bridge + addon install / update) |
+
+Full config reference: [`docs/agent.md` §四](docs/agent.md) / [`docs/context.md`](docs/context.md)
 
 ## Data locations
 
-Under `~/.pi/agent/`:
+App data lives under `~/.pi/agent/`; **shared** with Pi CLI: `auth.json` / `models.json`; everything else is **isolated**:
 
 | Path | Purpose |
 |---|---|
-| `x-agent.json` | Client preferences |
-| `x-agent/sessions/` | App sessions (isolated from Pi CLI) |
-| `x-agent/checkpoints/` | Shadow Git workspace checkpoints (per project) |
-| `x-agent/plans/` | Plan Mode plans (optional save to `<cwd>/.pi/plans/`) |
-| `x-agent-providers.json` | Provider profiles |
-| `x-agent-godot-rpc.json` | Godot RPC endpoint |
-| `x-agent-packages.json` | Installed Packages record |
-| `x-agent-usage.json` | Usage stats |
-| `auth.json` / `models.json` | Shared Pi auth & models |
+| `x-agent.json` | Client preferences (theme / default Thinking / sidebar width / etc.) |
+| `x-agent/sessions/` | App sessions (separate from Pi CLI's) |
+| `x-agent/checkpoints/` | Shadow Git checkpoints (per project, **does not touch your `.git`**) |
+| `x-agent/plans/` / `x-agent/goals/` | Plan files / Goal journals |
+| `x-agent-logos/` | Custom brand logos (UUID filenames, **do not edit outside the app**) |
+| `x-agent-{providers,packages,usage,godot-rpc}.json` | Profiles / install records / usage / RPC endpoint |
 
-## Related packages
+Full list: [`CLAUDE.md` §持久化与隔离](CLAUDE.md)
 
-| Package | Description |
-|---|---|
-| [`packages/godot-editor-rpc`](packages/godot-editor-rpc) | Godot editor RPC addon |
-| [`packages/godot-pi`](packages/godot-pi) | Godot domain skills & prompts |
+## Updates & installation
 
-## Updates & trust
-
-- **Auto-update**: packaged builds silently check **GitHub Releases** after launch (no auto-download). When a new version is found, an in-app prompt offers **Update now** / **Later**, and the TopBar shows a badge. Settings → General also has check / download / install. Use **Open Releases** if auto-update fails (or the contact channels below).
-- **Code signing**: Provide `CSC_LINK` + `CSC_KEY_PASSWORD` in the build env so electron-builder signs Windows installers (helps with SmartScreen). Builds still succeed without a certificate (unsigned).
+- **Auto-update**: packaged builds silently check [GitHub Releases](https://github.com/Fromlan/X-agent/releases) on launch (no auto-download). When a new version is found, an in-app prompt offers **Update now** / **Later**.
+- **Code signing**: optional `CSC_LINK` + `CSC_KEY_PASSWORD` to sign Windows installers (helps with SmartScreen). Builds still succeed without a certificate (unsigned).
 
 ## Security & privacy
 
-This is a coding agent with substantial local power—tighten as needed:
+A coding agent comes with substantial local power—tighten as needed.
 
-| Area | Notes |
-|---|---|
-| API keys | Encrypted at rest with Electron `safeStorage` when available (`x-agent-providers.json`); still written to Pi `auth.json` on activate |
-| Tools | Default allowlist includes `bash` / `write` / `edit`; Ask/Plan hard-gate closes write/edit; bash is read-only and cwd-bound (classifier + path check) without writing prefs |
-| Sandbox | Files tab and Ask/Plan bash are cwd-sandboxed; Agent-mode Pi `bash` can still reach broader paths |
-| Godot RPC | Listens on `127.0.0.1` only; endpoint includes a shared token validated on `editor_ready`. Update/restart the editor addon if handshake fails |
-| Packages | `pi install` accepts arbitrary sources—treat as supply-chain sensitive |
-| Sessions | Isolated under `~/.pi/agent/x-agent/sessions/`; Goal journals under `~/.pi/agent/x-agent/goals/` |
+### API keys
+- `x-agent-providers.json` is encrypted at rest with Electron `safeStorage` when available; on activation the key is also written in plaintext to Pi's `auth.json` (shared with Pi CLI)
+- On decryption failure (machine migration / keyring reset) the **on-disk ciphertext (`encryptedKey`) is preserved**—subsequent saves won't overwrite it with an empty string and lose the key
+- ⚠️ Don't sync `~/.pi/agent/` to untrusted locations
 
-## UI language
+### Tools
+- Defaults: `bash` / `write` / `edit` are on (active in **Agent / Goal modes**)
+- **Ask / Plan modes** hard-close `write` / `edit`; `bash` only allows read-only commands and paths must stay inside the project cwd
+- `read` / `grep` / `find` / `ls` path parameters are forced inside the project cwd
+- Godot tool toggles are validated at the IPC layer (a compromised UI cannot bypass a tool that's off by default)
 
-The desktop UI is currently **Chinese-only**. This English README documents the product; an in-app locale switch is not shipped yet. macOS/Linux installers are not shipped yet (Windows-first).
+### Network / processes
+- Godot RPC only listens on `127.0.0.1`; endpoints carry a shared token validated on `editor_ready` (handshake failure → update and restart the X-agent RPC addon)
+- Provider baseUrl rejects private networks / `*.nip.io` / `localtest.me` (SSRF guard)
+- `pi install` skips npm lifecycle scripts
 
-See [`CHANGELOG.md`](CHANGELOG.md) for release notes, [`CLAUDE.md`](CLAUDE.md) for development guidance, and [`docs/context.md`](docs/context.md) for Plan / Goal design notes.
+## FAQ
 
-## Feedback & Contributing
+**Q: Does it work offline?**
+A: Model calls need API (online); local usage / checkpoints / sessions / rollback are fully offline. The Godot docs skill `godot-docs-4-7` is auto-indexed inside Godot projects.
 
-- **Bug / feature requests**: open an Issue using one of the templates
-  (Bug report / Feature request / Question). Skim [`CHANGELOG.md`](CHANGELOG.md)
-  and existing Issues first.
-- **Security**: see [`SECURITY.md`](SECURITY.md). **Do not** post
-  reproduction details in a public Issue.
-- **Contributing**: read [`CONTRIBUTING.md`](CONTRIBUTING.md); use
-  Conventional Commits and the [PR template](.github/PULL_REQUEST_TEMPLATE.md).
-- **Maintenance cadence** (releases, weekly triage, Dependabot): see
-  [`docs/maintenance.md`](docs/maintenance.md).
-- **Code of conduct**: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md).
-- **License**: [`LICENSE`](LICENSE) (MIT).
+**Q: Why not just VS Code + Copilot?**
+A: 1) Godot editor RPC integration (scene introspection / debugger / resource hygiene) is out of reach for VS Code plugins. 2) Shadow Git rollback is isolated from your `.git` (VS Code doesn't restore by diff path). 3) 4 modes + 2 types are enforced at the IPC layer, not just suggested.
 
-## Contact & feedback
+**Q: Can I use it for non-Godot projects?**
+A: Technically yes (the IDE is Electron + Pi SDK, generic), but with all Godot tools off it degrades to a plain agent—**no differentiation value**.
+
+**Q: Does my data sync to the cloud?**
+A: No. Everything is local (see [Data locations](#data-locations)). Only model calls go through your configured provider.
+
+**Q: Will upgrades wipe my data?**
+A: No. Upgrades preserve everything under `~/.pi/agent/`. To roll back, install an older installer over the current one.
+
+## Feedback & contributing
+
+- **Bug / feature requests**: [Issues](../../issues) (three templates: Bug / Feature / Question)
+- **Security**: [`SECURITY.md`](SECURITY.md) — **do not** post reproduction details in a public issue
+- **Contributing**: [`CONTRIBUTING.md`](CONTRIBUTING.md) / [PR template](.github/PULL_REQUEST_TEMPLATE.md)
+- **Code of conduct**: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- **License**: [`LICENSE`](LICENSE) (MIT)
+- **Maintenance cadence**: [`docs/maintenance.md`](docs/maintenance.md)
+- **Roadmap**: [`docs/roadmap.md`](docs/roadmap.md) (22 milestones / 4 phases)
+
+Release notes: [`CHANGELOG.md`](CHANGELOG.md). Development guide: [`CLAUDE.md`](CLAUDE.md).
+
+## Credits
+
+- Built on [Pi SDK](https://pi.dev)
+- Status animations: [thinking-orbs](https://github.com/JakubAntalik/thinking-orbs) (MIT © Jakub Antalik)
+- Built-in logo presets: 8 in-house sets (Neon Cyber / Lava Burn / Plasma Thunder / Holographic Rainbow / Rose Gold Metallic / Pixel 8-bit / Glitch / Cosmic Nebula)
+
+## Contact
 
 | Channel | Details |
 |---|---|

--- a/README.en.md
+++ b/README.en.md
@@ -20,7 +20,6 @@
 <p align="center">
   <a href="#install">Install</a> ·
   <a href="#what-is-x-agent">Three pillars</a> ·
-  <a href="#x-agent-vs">Compare</a> ·
   <a href="docs/agent.md">Dev docs</a> ·
   <a href="docs/roadmap.md">Roadmap</a> ·
   <a href="CHANGELOG.md">Changelog</a> ·
@@ -82,26 +81,6 @@ X-agent does three things other agents don't: **deep Godot integration**, **trus
 - **Session types (orthogonal to mode)**:
   - **`code`** (default, writes unrestricted)
   - **`design`** — writes are **hard-confined** to `<cwd>/game-design/`, UI flips to a warm theme; 5 preinstalled skills: `design-initiation` / `design-process` / `design-systems` / `design-numerical` / `design-core-loop`
-
-## X-agent vs.
-
-**Comparison axes** (not just "does it work" — "what does it do that others don't"):
-
-| | VS Code + Copilot | Cursor | Claude Code | Pi CLI | **X-agent** |
-|---|---|---|---|---|---|
-| **Godot editor RPC** | ⚠️ Third-party plugins | 🚫 No | 🚫 No | 🚫 No | ✅ **Deep integration** (17 tools + 1.3 suite) |
-| **Rollback** | ⚠️ Rewinds messages | ⚠️ Rewinds messages | ⚠️ Rewinds messages | 🚫 No | ✅ **Shadow Git restores by diff path** |
-| **Mode hard-gate** (IPC layer) | 🚫 Suggestions only | 🚫 Suggestions only | ⚠️ Permission mode | ⚠️ Config file | ✅ **Session-level enforcement** (Agent / Ask / Plan / Goal) |
-| **Session types** | 🚫 No | 🚫 No | 🚫 No | 🚫 No | ✅ **`code` / `design` dual types** |
-| **Game-design workflow** | 🚫 No | 🚫 No | 🚫 No | 🚫 No | ✅ **5 preinstalled design skills + game-design hard-confine** |
-| **Local data** | ⚠️ Cloud-synced | ⚠️ Cloud-synced | ⚠️ Cloud-synced | ✅ Local | ✅ **Locally isolated** (separate dir from Pi CLI) |
-| **Windows installer** | ✅ | ✅ | ✅ | ⚠️ CLI-first | ✅ **NSIS double-click install** |
-| **Model-swappable** | ✅ | ✅ | ✅ | ✅ | ✅ **Multi-provider profiles + Thinking clamp** |
-| **UI language** | Multi-locale | Multi-locale | Multi-locale | EN | 🚧 **Chinese only** (English docs via `README.en.md`) |
-| **Open source** | Partial | 🚫 | 🚫 | ✅ MIT | ✅ MIT |
-| **Maintenance** | Commercial | Commercial | Commercial | Single-maintainer | 🚧 **Single-maintainer** (see [docs/maintenance.md](docs/maintenance.md)) |
-
-> ✅ = full support · ⚠️ = partial / needs config · 🚫 = unsupported · 🚧 = partial / WIP
 
 ## What do you want to do with X-agent?
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,50 +1,113 @@
-# X-agent
+<h1 align="center">X-agent</h1>
 
-[中文](README.md) · [English](README.en.md)
+<p align="center">
+  <img src="docs/screenshots/main-window.png" alt="X-agent main window" width="900"/>
+</p>
 
-[![Version](https://img.shields.io/badge/version-0.5.5-blue)](apps/desktop/package.json)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Platform: Windows](https://img.shields.io/badge/platform-Windows%2010%2F11-blueviolet)](#requirements)
-[![Godot: 4.x](https://img.shields.io/badge/Godot-4.x-478cbf)](#requirements)
+<p align="center">
+  <strong>A desktop coding agent for Godot 4: edit code, run scenes, and rewind to any step—all in the same session.</strong>
+</p>
 
-**A desktop coding agent for Godot 4**—edit scenes, modify scripts, run the scene, roll back: **all in one session**.
+<p align="center">
+  <a href="https://github.com/Fromlan/X-agent/releases/latest"><img src="https://img.shields.io/github/v/release/Fromlan/X-agent?label=latest" alt="Latest Release"/></a>
+  <img src="https://img.shields.io/badge/status-Early%20Beta-orange" alt="Status: Early Beta"/>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/Fromlan/X-agent" alt="License: MIT"/></a>
+  <a href="https://github.com/Fromlan/X-agent/stargazers"><img src="https://img.shields.io/github/stars/Fromlan/X-agent?style=flat" alt="GitHub Stars"/></a>
+  <img src="https://img.shields.io/badge/platform-Windows%2010%2F11-blueviolet" alt="Platform: Windows 10/11"/>
+  <img src="https://img.shields.io/badge/Godot-4.x-478cbf" alt="Godot 4.x"/>
+</p>
 
-Not a chat UI shell. Not a VS Code replacement. A **long-horizon coding agent**: Shadow Git rollback, hard mode gates, Thinking levels, branded client.
+<p align="center">
+  <a href="#install">Install</a> ·
+  <a href="#what-is-x-agent">Three pillars</a> ·
+  <a href="#x-agent-vs">Compare</a> ·
+  <a href="docs/agent.md">Dev docs</a> ·
+  <a href="docs/roadmap.md">Roadmap</a> ·
+  <a href="CHANGELOG.md">Changelog</a> ·
+  <a href="https://github.com/Fromlan/X-agent/issues">Issues</a>
+</p>
 
-![X-agent main window](docs/screenshots/main-window.png)
+<p align="center">
+  <a href="README.md">🇨🇳 简体中文</a> | <a href="README.en.md">🇺🇸 English</a>
+</p>
 
-> The desktop UI is currently **Chinese-only**. This English README documents the product; an in-app locale switch is not shipped yet.
+---
 
-## Table of contents
+> **Early Beta**: under active development; expect rough edges.
 
-- [30-second start](#30-second-start)
-- [What do you want to do with X-agent?](#what-do-you-want-to-do-with-x-agent)
-- [Key capabilities](#key-capabilities)
-- [Should I use X-agent?](#should-i-use-x-agent)
-- [Three concepts you must know](#three-concepts-you-must-know)
-- [Keyboard shortcuts](#keyboard-shortcuts)
-- [Settings](#settings)
-- [Data locations](#data-locations)
-- [Updates & installation](#updates--installation)
-- [Security & privacy](#security--privacy)
-- [FAQ](#faq)
-- [Feedback & contributing](#feedback--contributing)
-- [Credits](#credits)
-- [Contact](#contact)
+> Not AGI, but the most differentiated desktop agent in the Godot niche: editor RPC integration + Shadow Git rollback + 4 modes / 2 types hard-gated.
+
+## Install
+
+**Windows** (the only currently supported desktop platform):
+
+- **Installer**: [GitHub Releases](https://github.com/Fromlan/X-agent/releases/latest) — pick `X-agent-Setup-x.y.z.exe` and double-click
+- **In-app updates**: after install, launch silently checks for new versions (Settings → General, or the TopBar entry, can trigger manual checks)
+
+**macOS / Linux**: wait for the release—see [ROADMAP §1.3](docs/roadmap.md). Developers can run from source (see "From source" below).
 
 ## 30-second start
 
-1. **Download**: install the Windows package from [Releases](https://github.com/Fromlan/X-agent/releases/latest)
-2. **Open project**: pick your Godot project root (auto-resumes the latest session)
-3. **Authenticate**: Settings → General → "Open Pi login" (or `pi login` already signed in locally)
-4. **(Optional) Godot editor bridge**: Settings → Godot → Editor connection → install the **X-agent RPC** addon
-5. Type a prompt, press Enter
+1. Open the app and **Open project** to pick your Godot project root
+2. **Authenticate**: Settings → General → "Open Pi login" (or `pi login` already signed in locally)
+3. (Optional) **Bridge the Godot editor**: Settings → Godot → Editor connection → install the **X-agent RPC** addon → enable `x_agent_rpc` inside Godot
+4. Type a prompt, press Enter
 
-**Going deeper**: four role-based scenarios below.
+Going deeper: [role-based scenarios](#what-do-you-want-to-do-with-x-agent) / [settings overview](#settings) / [keyboard shortcuts](#keyboard-shortcuts).
+
+## What is X-agent?
+
+X-agent does three things other agents don't: **deep Godot integration**, **trustworthy rollback**, **hard mode gates**. Each pillar links to the deeper mechanism in [docs/agent.md](docs/agent.md).
+
+### 🎮 Deep Godot integration
+
+- **Editor RPC (TCP)** — the agent drives your running Godot editor: open / reload scenes, run current or main scene, capture play errors and stream them back. Default port `8765` (fallback `8765–8774`), with explicit multi-editor routing. See [docs/agent.md §七](docs/agent.md)
+- **17 Godot tools** — scene introspection (node tree / properties) / debugger (breakpoints / state) / resource hygiene (unused / lint / import) / export (headless sub-process) / config R/W (`project.godot`) / read-only introspection (global classes / export templates / UID resolution)
+- **`godot-docs-4-7` skill** — auto-discovered by Pi and surfaced in `<available_skills>`; load the full SKILL.md on demand via `read`—**0 tokens wasted on methodology you don't need**
+- **Ready checklist** — first-time setup wizard for Godot projects (auth / bash / RPC addon / Godot tools / docs)
+
+### ↩️ Trustworthy rollback
+
+- **Shadow Git checkpoints** (an independent checkpoint per prompt, isolated from your project's `.git`) → rewind / edit-resend / regenerate restores by diff path, **won't clobber edits you made during the turn**. Without Git, falls back to `write` / `edit` byte baselines
+- **Diff preview** (0.5.3+) — every turn shows `+/-`-colored diffs below the reply (with file count and `+N` / `-N` stats); the rewind confirmation dialog also shows a "what will be restored" diff so you can verify line-by-line
+- **Resumes survive restarts**: Shadow state persists across session restore
+
+### 🔀 4 modes + 2 types, hard-gated
+
+- **Session modes (mutually exclusive)**:
+  - **Agent** — normal coding (default allowlist)
+  - **Ask / Research** — read-only Q&A; hard-closes `write` / `edit` / `write_plan`; `bash` only allows read-only commands and paths must stay inside the project cwd
+  - **Plan** — read-only research + `write_plan`; editable plan in the right panel, save to project, **Build plan** switches back to Agent to implement
+  - **Goal** — set a completion condition; independent evaluator auto-continues while unmet (turn + token double budget)
+- **Session types (orthogonal to mode)**:
+  - **`code`** (default, writes unrestricted)
+  - **`design`** — writes are **hard-confined** to `<cwd>/game-design/`, UI flips to a warm theme; 5 preinstalled skills: `design-initiation` / `design-process` / `design-systems` / `design-numerical` / `design-core-loop`
+
+## X-agent vs.
+
+**Comparison axes** (not just "does it work" — "what does it do that others don't"):
+
+| | VS Code + Copilot | Cursor | Claude Code | Pi CLI | **X-agent** |
+|---|---|---|---|---|---|
+| **Godot editor RPC** | ⚠️ Third-party plugins | 🚫 No | 🚫 No | 🚫 No | ✅ **Deep integration** (17 tools + 1.3 suite) |
+| **Rollback** | ⚠️ Rewinds messages | ⚠️ Rewinds messages | ⚠️ Rewinds messages | 🚫 No | ✅ **Shadow Git restores by diff path** |
+| **Mode hard-gate** (IPC layer) | 🚫 Suggestions only | 🚫 Suggestions only | ⚠️ Permission mode | ⚠️ Config file | ✅ **Session-level enforcement** (Agent / Ask / Plan / Goal) |
+| **Session types** | 🚫 No | 🚫 No | 🚫 No | 🚫 No | ✅ **`code` / `design` dual types** |
+| **Game-design workflow** | 🚫 No | 🚫 No | 🚫 No | 🚫 No | ✅ **5 preinstalled design skills + game-design hard-confine** |
+| **Local data** | ⚠️ Cloud-synced | ⚠️ Cloud-synced | ⚠️ Cloud-synced | ✅ Local | ✅ **Locally isolated** (separate dir from Pi CLI) |
+| **Windows installer** | ✅ | ✅ | ✅ | ⚠️ CLI-first | ✅ **NSIS double-click install** |
+| **Model-swappable** | ✅ | ✅ | ✅ | ✅ | ✅ **Multi-provider profiles + Thinking clamp** |
+| **UI language** | Multi-locale | Multi-locale | Multi-locale | EN | 🚧 **Chinese only** (English docs via `README.en.md`) |
+| **Open source** | Partial | 🚫 | 🚫 | ✅ MIT | ✅ MIT |
+| **Maintenance** | Commercial | Commercial | Commercial | Single-maintainer | 🚧 **Single-maintainer** (see [docs/maintenance.md](docs/maintenance.md)) |
+
+> ✅ = full support · ⚠️ = partial / needs config · 🚫 = unsupported · 🚧 = partial / WIP
 
 ## What do you want to do with X-agent?
 
-### 🎮 Godot developer · edit code + run scene
+Four common scenarios, choose by role:
+
+### 🎮 Godot developer · edit code + run scenes
 Open project → Agent mode → pick model → ask "add a dash to `Player.gd` and run the current scene" → Agent edits the file, editor RPC reloads, runs the scene, error messages stream back—**all in the same session**.
 
 ### ✍️ Solo game designer · write design docs (keep `game/` clean)
@@ -58,32 +121,25 @@ Switch to **Goal mode** → set a completion condition (e.g. "add combo counter 
 
 ## Key capabilities
 
-| | |
-|---|---|
-| **🎯 Design sessions** | Writes hard-confined to `<cwd>/game-design/`, warm theme UI. 5 preinstalled skills: `design-initiation` / `design-process` / `design-systems` / `design-numerical` / `design-core-loop` |
-| **🎮 Godot integration** | Editor RPC (port 8765, fallback 8765–8774); 17 tools spanning scene introspection / debugger / resource hygiene / export / config R/W / read-only introspection |
-| **📜 godot-docs-4-7** | Engine-conventions skill (auto-discovered by Pi); load SKILL.md on demand via `read`—**0 tokens wasted on methodology you don't need** |
-| **↩️ Shadow Git rollback** | Per-turn checkpoints isolated from your `.git`; restores by diff path (won't clobber edits you made during the turn) |
-| **🔀 4 modes + 2 types** | Mutually exclusive modes: Agent / Ask / Plan / Goal; `code` / `design` session types (orthogonal to mode) |
-| **⚡ Diff display** | Inspect `+/-`-colored diffs before retracting (with file count and `+N` / `-N` stats) |
-| **🎨 8 built-in logos + custom upload** | Settings → General → Brand: Neon Cyber / Lava Burn / Plasma Thunder / Holographic Rainbow / Rose Gold Metallic / Pixel 8-bit / Glitch / Cosmic Nebula |
-| **🧠 Thinking levels + thinking-orbs** | Auto-clamp Thinking for models like DeepSeek; particle-orbit animation while running, not a spinner |
-| **🎨 v1.1 design language** | Elevation-driven hierarchy: the Composer is the single main element; chrome (TopBar / Sidebar / RightPanel) steps back; 10 theme families (default / nord / tokyo / paper / contrast × dark/light) |
+| Capability | Version | What you see |
+|---|---|---|
+| **🎯 Design session type** | 0.5.5 | Writes hard-confined to `<cwd>/game-design/`, warm theme UI |
+| **🛠 5 preinstalled design skills** | 0.5.5 | Initiation / process / systems / numerical / core loop, ready to use |
+| **🎨 8 built-in logos + custom upload** | 0.5.5 | Settings → General → Brand (Neon Cyber / Lava Burn / …) |
+| **🎨 v1.1 elevation design language** | 0.5.4 | Composer as the single main element; chrome steps back |
+| **⚡ Diff display** | 0.5.3 | `+/-`-colored diff before rewind, with `+N` / `-N` stats |
+| **🔮 thinking-orbs status animation** | 0.5.2 | Particle-orbit animation while running, not a spinner |
+| **📜 godot-docs-4-7** | 0.4.x | Engine-conventions skill, loaded on demand |
+| **↩️ Shadow Git rollback** | 0.4.x | Per-turn checkpoints, restore by diff path |
+| **🎯 4 modes + 2 types hard-gate** | 0.3.6+ | Agent / Ask / Plan / Goal × code / design |
+| **🧠 Thinking levels + model clamp** | 0.2.5+ | Auto-clamp for DeepSeek etc., live editor feedback |
 
-## Should I use X-agent?
-
-| Your situation | Recommendation |
-|---|---|
-| Building a Godot 4 project, **Windows** | ✅ Install it |
-| Building a Godot 4 project, **macOS / Linux** | ⏸ Wait for macOS / Linux installers ([ROADMAP 3.4](docs/roadmap.md)) |
-| Using Unity / Unreal / general coding | ❌ Not a fit (Godot-specialized) |
-| Just want to try LLM chat | ❌ Use [Pi CLI](https://pi.dev) directly—lighter |
-| Need cloud / real-time collaboration | ❌ Local desktop, single-maintainer project |
+Full changelog: [`CHANGELOG.md`](CHANGELOG.md).
 
 ## Three concepts you must know
 
 - **Session mode** (mutually exclusive): Agent / Ask / Plan / Goal—decides **which tools are available**
-- **Session type** (orthogonal): `code` (default) / `design`—decides the **scope of writes**
+- **Session type** (orthogonal): `code` / `design`—decides the **scope of writes**
 - **Rollback source**: Shadow Git checkpoints (isolated from your `.git`); restores by diff path
 
 ## Keyboard shortcuts
@@ -166,6 +222,35 @@ A: No. Everything is local (see [Data locations](#data-locations)). Only model c
 **Q: Will upgrades wipe my data?**
 A: No. Upgrades preserve everything under `~/.pi/agent/`. To roll back, install an older installer over the current one.
 
+## From source
+
+Developer docs: [`docs/agent.md`](docs/agent.md) / [`CLAUDE.md`](CLAUDE.md)
+
+```bash
+git clone https://github.com/Fromlan/X-agent.git
+cd X-agent
+cd apps/desktop
+npm install
+npm run dev          # Electron dev
+npm test             # offline assertion chain
+npm run test:unit    # vitest
+npm run typecheck    # tsc (two tsconfigs)
+```
+
+Release flow: see [`CLAUDE.md` §7](CLAUDE.md#7-发版流程).
+
+## Roadmap
+
+22 milestones / 4 phases. Current state:
+
+- ✅ **Phase 1** Engineering quality + Godot deepening (1.1 Vitest+Playwright / 1.2 seven new Godot tools / 1.4 lint / 1.5 @-completion / 1.6 E2E contract locks)
+- 🛑 **1.3 i18n basics** — deprecated (single-maintainer; English docs via `README.en.md`, UI stays Chinese-only for now)
+- ⏳ **Phase 2** UX polish: session export / dev diagnostics / Plan templates / A11y
+- ⏳ **Phase 3** Differentiation: theme editor / shortcut center / multi-project workspace
+- ⏳ **Phase 3.4** macOS / Linux installers
+
+Full roadmap: [`docs/roadmap.md`](docs/roadmap.md)
+
 ## Feedback & contributing
 
 - **Bug / feature requests**: [Issues](../../issues) (three templates: Bug / Feature / Question)
@@ -174,15 +259,13 @@ A: No. Upgrades preserve everything under `~/.pi/agent/`. To roll back, install 
 - **Code of conduct**: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 - **License**: [`LICENSE`](LICENSE) (MIT)
 - **Maintenance cadence**: [`docs/maintenance.md`](docs/maintenance.md)
-- **Roadmap**: [`docs/roadmap.md`](docs/roadmap.md) (22 milestones / 4 phases)
-
-Release notes: [`CHANGELOG.md`](CHANGELOG.md). Development guide: [`CLAUDE.md`](CLAUDE.md).
 
 ## Credits
 
-- Built on [Pi SDK](https://pi.dev)
+- Built on [Pi SDK](https://pi.dev) — the core for context assembly / sessions / compaction
 - Status animations: [thinking-orbs](https://github.com/JakubAntalik/thinking-orbs) (MIT © Jakub Antalik)
-- Built-in logo presets: 8 in-house sets (Neon Cyber / Lava Burn / Plasma Thunder / Holographic Rainbow / Rose Gold Metallic / Pixel 8-bit / Glitch / Cosmic Nebula)
+- Godot docs: indexed [godot-docs-4-7](https://godotengine.org/) skill
+- Inspired by [Karpathy on LLM Knowledgebases](https://x.com/karpathy/status/2039805659525644595)
 
 ## Contact
 
@@ -190,3 +273,9 @@ Release notes: [`CHANGELOG.md`](CHANGELOG.md). Development guide: [`CLAUDE.md`](
 |---|---|
 | Email | [fromlan@qq.com](mailto:fromlan@qq.com) |
 | QQ group | `1074500101` |
+
+---
+
+<p align="center">
+  <sub>If X-agent helps you, <a href="https://github.com/Fromlan/X-agent">drop a ⭐ Star</a> so others can find it.</sub>
+</p>

--- a/README.md
+++ b/README.md
@@ -2,138 +2,187 @@
 
 [中文](README.md) · [English](README.en.md)
 
-面向 **Godot 4** 的桌面编码 Agent，基于 [Pi](https://pi.dev)。
+[![Version](https://img.shields.io/badge/version-0.5.5-blue)](apps/desktop/package.json)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Platform: Windows](https://img.shields.io/badge/platform-Windows%2010%2F11-blueviolet)](#环境要求)
+[![Godot: 4.x](https://img.shields.io/badge/Godot-4.x-478cbf)](#环境要求)
 
-在项目里改场景与脚本、通过编辑器 RPC 重载 / 运行 / 导入，并用 godot-docs-4-7 技能查阅引擎惯例——同一套会话里完成。当前版本见 [`apps/desktop/package.json`](apps/desktop/package.json)。
+**Godot 4 项目的桌面编码 Agent**——改场景、改脚本、跑场景、回滚，**在同一会话里完成**。
 
-## 定位
+不是聊天工具的 UI 壳；不是 VS Code 替代品；是**长任务型 Agent**：回滚靠 Shadow Git、模式硬闸、Thinking 档位、品牌化客户端。
+
+![X-agent 主界面](docs/screenshots/main-window.png)
+
+## 目录
+
+- [30 秒上手](#30-秒上手)
+- [你要用 X-agent 做什么？](#你要用-x-agent-做什么)
+- [关键能力](#关键能力)
+- [我该不该用 X-agent？](#我该不该用-x-agent)
+- [三个必知概念](#三个必知概念)
+- [键盘快捷键](#键盘快捷键)
+- [设置](#设置)
+- [数据位置](#数据位置)
+- [更新 & 安装](#更新--安装)
+- [安全与隐私](#安全与隐私)
+- [常见问题](#常见问题)
+- [反馈与贡献](#反馈与贡献)
+- [致谢](#致谢)
+- [联系](#联系)
+
+## 30 秒上手
+
+1. **下载**：[Releases](https://github.com/Fromlan/X-agent/releases/latest) 装 Windows 安装包
+2. **打开项目**：选 Godot 工程目录（自动续最近会话）
+3. **登录认证**：设置 → 通用 → 打开 Pi 登录（或本机 `pi login` 已登录）
+4. **（可选）Godot 编辑器连接**：设置 → Godot → 编辑器连接 → 安装 **X-agent RPC** 插件
+5. 输 prompt，按回车
+
+**深入**：下方按 4 类角色场景展开。
+
+## 你要用 X-agent 做什么？
+
+### 🎮 Godot 开发者 · 改代码 + 跑场景
+打开项目 → Agent 模式 → 选模型 → 问"在 `Player.gd` 加冲刺功能，跑一下当前场景" → Agent 改文件、编辑器 RPC 重载、跑场景、报错回传，**都在同一会话**。
+
+### ✍️ 独立策划 · 写设计文档（不污染 game/）
+新会话选 **design 类型** → 写只允许落到 `<cwd>/game-design/` → 预装 5 个内置 design skill 帮你做立项 / 数值 / 核心循环 → UI 切暖色主题与代码会话区分。
+
+### 🔬 研究只读 · 问 API、查文档
+切 **调研 (Ask) 模式** → 工具集硬闸关 `write` / `edit` → `bash` 仅放行只读命令且路径须在项目 cwd 内 → 适合"先摸清 GDScript 单例怎么写再动手"。
+
+### 🎯 目标驱动 · 让 Agent 自己跑到完成
+切 **目标 (Goal) 模式** → 写完成条件（如"在 `ScoreManager.gd` 加 combo 计数 + HUD 显示"） → 评估未达自动续轮（轮次 + token 双预算）。
+
+## 关键能力
 
 | | |
 |---|---|
-| 是什么 | Godot 专用的编码 Agent（Electron 桌面客户端） |
-| 不是什么 | 通用多语言 IDE 替代品；Godot 是核心工作面（不是"一个插件"） |
-| 工作面 | 项目文件 + Godot 编辑器控制面 + Godot 惯例技能 |
-| 运行时 | 复用 Pi 认证与模型；会话与 Pi CLI 隔离 |
+| **🎯 策划会话 (design)** | 写操作硬约束到 `<cwd>/game-design/`，UI 暖色主题。预装 5 个内置 skill：`design-initiation` / `design-process` / `design-systems` / `design-numerical` / `design-core-loop` |
+| **🎮 Godot 集成** | 编辑器 RPC（端口 8765，8765–8774 回退）；17 个工具覆盖场景内省 / 调试器 / 资源治理 / 导出 / 配置读写 / 只读内省 |
+| **📜 godot-docs-4-7** | 引擎惯例技能（Pi 自动发现）；按需 `read` SKILL.md，**0 token 浪费在"用不上的方法论"上** |
+| **↩️ Shadow Git 撤回** | 每轮检查点独立于你的 `.git`，按 diff 路径还原（**不会吞掉回合期间你的手动编辑**） |
+| **🔀 4 模式 + 2 类型** | 互斥切换：Agent / 调研(Ask) / Plan / 目标(Goal)；`code` / `design` 类型（与模式正交） |
+| **⚡ Diff 显示** | 撤回前看 `+/-` 着色 diff（带文件数 / `+N` / `-N` 统计），确认无误再点撤回 |
+| **🎨 8 套品牌 logo + 自定义** | 设置 → 通用 → 品牌：霓虹赛博 / 熔岩灼烧 / 电浆雷霆 / 全息彩虹 / 玫瑰金金属 / 像素 8-bit / 故障 Glitch / 宇宙星云 |
+| **🧠 思考档位 + thinking-orbs** | DeepSeek 等模型自动钳制 Thinking；运行中粒子轨道而非转圈 |
+| **🎨 v1.1 设计语言** | elevation 驱动：Composer 是整窗唯一主元素，三栏壳层（TopBar / Sidebar / RightPanel）降为低调 chrome；10 主题族（default / nord / tokyo / paper / contrast × dark/light） |
 
-## 功能
+## 我该不该用 X-agent？
 
-### Godot
-
-- **编辑器 RPC** — 开/重载场景、运行当前或主场景、资源导入、多编辑器选路、运行报错回传；默认端口 `8765`（回退 `8765–8774`）
-- **Godot 惯例技能** — godot-pi 包内 `godot-docs-4-7`（Godot 项目自动索引）
-- **Godot Pi 包** — 领域 skills / prompts（设置 → 插件可一键安装）
-- **右栏 Godot** — 桥接连接状态与快捷操作
-- **项目就绪清单** — 认证 / bash·Git / RPC 插件 / Godot 工具 / 文档等一步引导；可「不再提醒」
-
-### Agent 与会话
-
-- **聊天** — 打开项目、续会话、流式中 steer / 中止；Thinking；`@路径` 引用文件（发送后以芯片展示，可展开）
-- **会话模式** — 输入区 **Agent | 调研 | Plan | 目标** 四模式互斥切换
-  - **Agent** — 常规编码（工具白名单内）
-  - **Plan** — 只读研究 + `write_plan`；右栏「计划」可编辑 / 保存到项目；审阅后点「执行计划」切回 Agent 实施；tool_call 硬闸防误写
-  - **目标（Goal）** — 设定完成条件，独立评估未达标则自动续轮
-- **会话** — 按项目分组；恢复 / 重命名 / 删除；自动标题；可从侧栏隐藏项目
-- **对话编辑** — 撤回、编辑重发、重新生成；优先用 Shadow Git 检查点**按 diff 路径还原**工作区（独立于用户 `.git`；仅还原回合内变化过的文件，保留回合期间你的手动编辑），无 Git 时降级为还原该段 `write` / `edit` 基线；撤回前有确认与风险提示
-- **技能可见** — `read` 加载 `SKILL.md` 时显示为「技能 · 名称」卡片
-- **右栏** — 上下文占用拆解与手动压缩、**计划**、工具详情、项目文件树（Markdown 可预览）、Godot 状态
-
-### 配置与运维
-
-- **供应商** — 多档案订阅、拉取模型列表；可导入 Pi / cc-switch 配置；DeepSeek 等模型 Thinking 档位自动钳制与修复
-- **插件** — Prompt / Skill / Extension / Theme / Packages
-- **工具白名单** — 内置读写与终端默认开；Godot 编辑器 / 文档工具默认关，可按组开关；临时只读用会话「调研」或 Plan（不改设置勾选）
-- **用量** — 本地用量汇总（设置 → 用量）
-- **认证** — 应用内 Pi 登录引导
-- **主题** — 深色默认 / 浅色；设置与顶栏可切换
-- **更新** — 安装版静默检查 GitHub Releases（不自动下载）；发现新版本时应用内提示 + 顶栏入口；设置内也可检查 / 下载 / 安装；失败时可打开 Releases
-
-## 环境要求
-
-- Windows（当前提供安装包）
-- Godot **4.x** 项目（使用编辑器控制面时）
-- Node.js 24+（仅从源码开发时需要）
-- 可用的模型认证（任选）：
-  - **设置 → 供应商** 新建并启用
-  - **设置 → 通用** →「打开 Pi 登录」
-  - 本机已登录 [Pi CLI](https://pi.dev)
-- 终端类工具：建议安装 [Git for Windows](https://git-scm.com/download/win)，或在设置中指定 bash 路径（`shellPath`）
-
-## 使用
-
-1. 打开应用，**打开项目**选择 Godot 工程目录（默认续该项目最近会话）
-2. 输入框下方选择模型与 Thinking，按需切换 **Agent / 调研 / Plan / 目标**（也可 Shift+Tab 循环），发送指令
-3. 使用 Godot 控制面时：
-   - **设置 → 工具** 勾选 Godot 编辑器 / 文档工具
-   - **设置 → Godot → 编辑器连接**：安装/启用 **X-agent RPC** 插件，保持桥接已连接
-   - （可选）**设置 → 插件** 一键安装 Godot Pi 包（含 `godot-docs-4-7`）
-4. 左侧管理历史；右栏查看上下文、计划、工具、文件与 Godot 状态
-5. Plan 流程：切到 Plan → 描述任务 → Agent 研究后写出计划 → 右栏审阅/编辑 →「执行计划」
-
-| 设置分页 | 内容 |
+| 你的情况 | 建议 |
 |---|---|
-| 通用 | 主题、Thinking 默认、bash、Pi 登录、自动更新 |
-| 供应商 | 模型供应商档案与导入 |
-| 用量 | 本地用量汇总 |
-| 工具 | 工具白名单、分组开关（Agent/目标默认能力；临时只读用会话模式） |
-| 插件 | 提示词 / 技能 / 扩展 / 主题 / Packages |
-| Godot | **编辑器连接** |
+| 做 Godot 4 项目，**Windows** | ✅ 直接装 |
+| 做 Godot 4 项目，**macOS / Linux** | ⏸ 等 macOS / Linux 安装包（[ROADMAP 3.4](docs/roadmap.md)） |
+| 用 Unity / Unreal / 通用编码 | ❌ 不合适（Godot 专精） |
+| 只想试 LLM 聊天 | ❌ 直接用 [Pi CLI](https://pi.dev) 更轻 |
+| 想要云端多人协作 | ❌ 本机桌面型，单人项目 |
+
+## 三个必知概念
+
+- **会话模式**（互斥）：Agent / 调研(Ask) / Plan / 目标(Goal)，决定**能用什么工具**
+- **会话类型**（独立）：`code`（默认）/ `design`，写操作的**作用域**
+- **撤回源**：Shadow Git 检查点（独立于你的 `.git`），按 diff 路径还原
+
+## 键盘快捷键
+
+| 快捷键 | 作用 |
+|---|---|
+| `Shift+Tab` | 循环切换模式 |
+| `F12` / `Ctrl+Shift+I` | DevTools（需 `--x-agent-debug` / `X_AGENT_DEBUG=1`） |
+| `Esc` | 关闭当前弹窗 |
+| `Ctrl+,` | 打开设置 |
+| `Ctrl+Enter` | 多行输入时发送消息 |
+
+## 设置
+
+| 分页 | 内容 |
+|---|---|
+| 通用 | 主题、Thinking 默认、bash 路径、Pi 登录、自动更新、**品牌（logo 选择）** |
+| 供应商 | 模型档案、导入 Pi / cc-switch 配置、Thinking 钳制 |
+| 用量 | 本地按日 / 按模型汇总 |
+| 工具 | 内置 / Godot 编辑器 / Godot 文档 工具白名单；Agent / Goal 模式生效 |
+| 插件 | Prompt / Skill / Extension / Theme / Packages（Pi 五类） |
+| Godot | **编辑器连接**（RPC 桥 + 插件安装/更新） |
+
+完整配置项：[`docs/agent.md` §四](docs/agent.md) / [`docs/context.md`](docs/context.md)
 
 ## 数据位置
 
-应用数据在 `~/.pi/agent/` 下：
+应用数据在 `~/.pi/agent/` 下；与 Pi CLI **共用** `auth.json` / `models.json`，其余**隔离**：
 
 | 路径 | 用途 |
 |---|---|
-| `x-agent.json` | 客户端偏好 |
-| `x-agent/sessions/` | 本应用会话（与 Pi CLI 隔离） |
-| `x-agent/checkpoints/` | Shadow Git 工作区检查点（按项目隔离） |
-| `x-agent/plans/` | Plan Mode 默认计划文件（可保存到 `<cwd>/.pi/plans/`） |
-| `x-agent-providers.json` | 供应商档案 |
-| `x-agent-godot-rpc.json` | Godot RPC endpoint（含握手 token） |
-| `x-agent/goals/` | Goal 模式日记（删除会话时清理） |
-| `x-agent-packages.json` | Packages 安装记录 |
-| `x-agent-usage.json` | 用量统计 |
-| `auth.json` / `models.json` | 与 Pi 共用的认证与模型 |
+| `x-agent.json` | 客户端偏好（含 theme / Thinking 默认 / sidebar 宽度等） |
+| `x-agent/sessions/` | 本应用会话（与 Pi CLI 分开） |
+| `x-agent/checkpoints/` | Shadow Git 检查点（按项目隔离，**不写你的 .git**） |
+| `x-agent/plans/` / `x-agent/goals/` | Plan 文件 / Goal 日记 |
+| `x-agent-logos/` | 自定义品牌 logo（UUID 文件名，**应用外勿编辑**） |
+| `x-agent-{providers,packages,usage,godot-rpc}.json` | 档案 / 安装记录 / 用量 / RPC endpoint |
 
-## 相关包
+完整清单：[`CLAUDE.md` §持久化与隔离](CLAUDE.md)
 
-| 包 | 说明 |
-|---|---|
-| [`packages/godot-editor-rpc`](packages/godot-editor-rpc) | Godot 编辑器 RPC 插件 |
-| [`packages/godot-pi`](packages/godot-pi) | Godot 领域 skills 与 prompts |
+## 更新 & 安装
 
-## 更新与安装信任
-
-- **自动更新**：安装版启动后会静默检查 **GitHub Releases**（不会自动下载）。发现新版本时应用内提示「立即更新 / 稍后」，顶栏也有入口；也可在设置 → 通用手动检查 / 下载 / 安装。检查失败时可点「打开 Releases」在浏览器下载（网络不稳时可用下方交流渠道）。
-- **代码签名**：打包时若环境提供 `CSC_LINK`（证书文件/base64）与 `CSC_KEY_PASSWORD`，electron-builder 会自动签名，减轻 SmartScreen 拦截。未配置证书时仍可产出未签名安装包。
+- **自动更新**：安装版启动后静默检查 [GitHub Releases](https://github.com/Fromlan/X-agent/releases)（不自动下载）。有新版本时应用内提示「立即更新 / 稍后」。
+- **代码签名**：可选 `CSC_LINK` + `CSC_KEY_PASSWORD`（缓解 SmartScreen 拦截）。未配置仍可装。
 
 ## 安全与隐私
 
-编码 Agent 默认具备较强本机能力，请按需收紧：
+编码 Agent 默认具备较强本机能力，请按需收紧。
 
-| 面 | 说明 |
-|---|---|
-| API Key | 供应商密钥在 `x-agent-providers.json` 中尽量用 Electron `safeStorage` 加密；激活时仍写入 Pi `auth.json`；勿把该目录同步到不可信位置 |
-| 工具 | 默认开启 `bash` / `write` / `edit`；会话「调研」/ Plan 硬闸关闭 write/edit，bash 仅放行只读命令且路径须在项目 cwd 内（不写回设置），`read`/`grep`/`find`/`ls` 的路径参数同样强制 cwd 内；设置 → 工具控制 Agent/目标默认白名单，Godot 工具开关在 IPC 层强制校验（默认关闭时被攻陷的界面也无法绕过） |
-| 项目沙箱 | 右栏文件树与调研/Plan 的 bash 受 cwd 约束；Agent 模式下 Pi `bash` 仍可能访问更广路径 |
-| Godot RPC | 仅监听 `127.0.0.1`；endpoint 含共享 token，插件 `editor_ready` 握手校验后才接受调用；多编辑器显式选路，未鉴权客户端不会静默改道。握手失败时请更新并重启编辑器内 `x_agent_rpc` 插件 |
-| Packages | `pi install` 可安装任意来源包，注意供应链风险 |
-| 会话 | 仅存储在 `~/.pi/agent/x-agent/sessions/`，与 Pi CLI 会话隔离；Goal journal 在 `~/.pi/agent/x-agent/goals/` |
+### API Key
+- `x-agent-providers.json` 默认用 Electron `safeStorage` 加密；激活时明文写入 Pi `auth.json`（与 Pi CLI 共用）
+- 解密失败（换机器 / keyring 重置）时**保留盘上密文** `encryptedKey`，不覆盖——避免密钥永久丢失
+- ⚠️ 不要把 `~/.pi/agent/` 同步到不可信位置
 
-变更记录见 [`CHANGELOG.md`](CHANGELOG.md)。开发与贡献说明见 [`CLAUDE.md`](CLAUDE.md)。Plan / Goal 设计见 [`docs/context.md`](docs/context.md)。
+### 工具
+- 默认开 `bash` / `write` / `edit`（**Agent / Goal 模式**）
+- **调研 / Plan 模式**硬闸关 `write` / `edit`；`bash` 仅放行只读命令且路径须在项目 cwd 内
+- `read` / `grep` / `find` / `ls` 路径参数强制 cwd 内
+- Godot 工具开关在 IPC 层校验（被攻陷 UI 也无法绕过默认关闭项）
+
+### 网络 / 进程
+- Godot RPC 仅监听 `127.0.0.1`，endpoint 含共享 token（握手失败 → 更新并重启 X-agent RPC 插件）
+- Provider baseUrl 拒绝私网 / `*.nip.io` / `localtest.me`（防 SSRF）
+- `pi install` 跳过 npm lifecycle scripts
+
+## 常见问题
+
+**Q: 在线 / 离线能用吗？**
+A: 模型调用走 API（在线）；本地用量 / 检查点 / 会话 / 撤回全部离线。Godot 文档技能 `godot-docs-4-7` 在 Godot 项目内自动索引。
+
+**Q: 为什么不用 VS Code + Copilot？**
+A: 1) Godot 编辑器 RPC 联动（场景内省 / 调试器 / 资源治理）VS Code 插件做不到；2) Shadow Git 撤回独立于你的 `.git`（VS Code 不会按 diff 路径还原）；3) 4 模式 + 2 类型硬闸（VS Code 插件是建议，X-agent 是 IPC 层强制）。
+
+**Q: 可以用在非 Godot 项目吗？**
+A: 可以（IDE 本身是 Electron + Pi SDK 通用），但 Godot 工具全部关掉就退化成普通 Agent，**没有差异化价值**。
+
+**Q: 数据会同步到云吗？**
+A: 不会。本机持久化（见 [数据位置](#数据位置)）。仅模型调用走你配置的 provider。
+
+**Q: 升级会丢数据吗？**
+A: 不会。升级保留 `~/.pi/agent/` 下所有内容。如需回滚到旧版，直接装旧 installer 覆盖。
 
 ## 反馈与贡献
 
-- **Bug / 功能请求**：在 [Issues](../../issues) 用模板（Bug report / Feature request / Question）发起。提交前先看 [`CHANGELOG.md`](CHANGELOG.md) 与 [已有 Issue](../../issues)。
-- **安全漏洞**：见 [`SECURITY.md`](SECURITY.md)，**不要**在公开 Issue 里贴复现细节。
-- **参与开发**：先读 [`CONTRIBUTING.md`](CONTRIBUTING.md)；commit 用 Conventional Commits，PR 用 `.github/PULL_REQUEST_TEMPLATE.md`。
-- **维护节奏**（发版、Issue 周维护、Dependabot）：见 [`docs/maintenance.md`](docs/maintenance.md)。
-- **行为准则**：[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)。
-- **协议**：[`LICENSE`](LICENSE) (MIT)。
+- **Bug / 功能请求**：[Issues](../../issues)（Bug / Feature / Question 3 类模板）
+- **安全漏洞**：[`SECURITY.md`](SECURITY.md) — **不要**在公开 Issue 贴复现
+- **参与开发**：[`CONTRIBUTING.md`](CONTRIBUTING.md) / [PR 模板](.github/PULL_REQUEST_TEMPLATE.md)
+- **行为准则**：[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
+- **协议**：[`LICENSE`](LICENSE) (MIT)
+- **维护节奏**：[`docs/maintenance.md`](docs/maintenance.md)
+- **路线图**：[`docs/roadmap.md`](docs/roadmap.md)（22 里程碑 / 4 Phase）
 
-## 交流与反馈
+变更记录见 [`CHANGELOG.md`](CHANGELOG.md)。开发与贡献说明见 [`CLAUDE.md`](CLAUDE.md)。
 
-欢迎反馈问题、建议与使用体验：
+## 致谢
+
+- 基于 [Pi SDK](https://pi.dev)
+- 状态行动画：[thinking-orbs](https://github.com/JakubAntalik/thinking-orbs) (MIT © Jakub Antalik)
+- Logo 预设：内部 8 套（霓虹赛博 / 熔岩灼烧 / 电浆雷霆 / 全息彩虹 / 玫瑰金金属 / 像素 8-bit / 故障 Glitch / 宇宙星云）
+
+## 联系
 
 | 渠道 | 联系方式 |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -83,26 +83,6 @@ X-agent 做三件其他 Agent 没做好的事：**Godot 深度联动**、**可�
   - **`code`**（默认，写入无限制）
   - **`design`** —— 写操作**硬约束**到 `<cwd>/game-design/`，UI 切暖色主题；预装 5 个内置 skill：`design-initiation` / `design-process` / `design-systems` / `design-numerical` / `design-core-loop`
 
-## X-agent vs.
-
-**对比维度**（不只比"能不能用"——比"做了别人没做的事"）：
-
-| | VS Code + Copilot | Cursor | Claude Code | Pi CLI | **X-agent** |
-|---|---|---|---|---|---|
-| **Godot 编辑器 RPC** | ⚠️ 需第三方插件 | 🚫 无 | 🚫 无 | 🚫 无 | ✅ **深度集成**（17 工具 + 1.3 套件） |
-| **撤回机制** | ⚠️ 撤 message | ⚠️ 撤 message | ⚠️ 撤 message | 🚫 无 | ✅ **Shadow Git 按 diff 路径还原** |
-| **模式硬闸**（IPC 层） | 🚫 仅建议 | 🚫 仅建议 | ⚠️ permission mode | ⚠️ 配置文件 | ✅ **会话级强制**（Agent / Ask / Plan / Goal） |
-| **会话类型** | 🚫 无 | 🚫 无 | 🚫 无 | 🚫 无 | ✅ **`code` / `design` 双类型** |
-| **策划工作流支持** | 🚫 无 | 🚫 无 | 🚫 无 | 🚫 无 | ✅ **5 内置 design skill + game-design 硬约束** |
-| **数据本地** | ⚠️ 同步到云 | ⚠️ 同步到云 | ⚠️ 同步到云 | ✅ 本地 | ✅ **本机隔离**（与 Pi CLI 分目录） |
-| **Windows 安装包** | ✅ | ✅ | ✅ | ⚠️ CLI 为主 | ✅ **NSIS 双击安装** |
-| **模型可换** | ✅ | ✅ | ✅ | ✅ | ✅ **多 provider 档案 + Thinking 钳制** |
-| **UI 语言** | 多语种 | 多语种 | 多语种 | EN | 🚧 **中文 only**（英文文档由 README.en.md 承担） |
-| **开源** | 部分 | 🚫 | 🚫 | ✅ MIT | ✅ MIT |
-| **维护模式** | 商业 | 商业 | 商业 | 个人项目 | 🚧 **单兵项目**（见 [docs/maintenance.md](docs/maintenance.md)） |
-
-> ✅ = 完整支持　⚠️ = 部分 / 需配置　🚫 = 不支持　🚧 = 部分 / 在做
-
 ## 你要用 X-agent 做什么？
 
 四个常见场景，按"我是什么角色"选：

--- a/README.md
+++ b/README.md
@@ -1,46 +1,111 @@
-# X-agent
+<h1 align="center">X-agent</h1>
 
-[中文](README.md) · [English](README.en.md)
+<p align="center">
+  <img src="docs/screenshots/main-window.png" alt="X-agent 主界面" width="900"/>
+</p>
 
-[![Version](https://img.shields.io/badge/version-0.5.5-blue)](apps/desktop/package.json)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
-[![Platform: Windows](https://img.shields.io/badge/platform-Windows%2010%2F11-blueviolet)](#环境要求)
-[![Godot: 4.x](https://img.shields.io/badge/Godot-4.x-478cbf)](#环境要求)
+<p align="center">
+  <strong>Godot 4 项目的桌面编码 Agent：同会话里改代码、跑场景、撤回到任意一步。</strong>
+</p>
 
-**Godot 4 项目的桌面编码 Agent**——改场景、改脚本、跑场景、回滚，**在同一会话里完成**。
+<p align="center">
+  <a href="https://github.com/Fromlan/X-agent/releases/latest"><img src="https://img.shields.io/github/v/release/Fromlan/X-agent?label=latest" alt="Latest Release"/></a>
+  <img src="https://img.shields.io/badge/status-Early%20Beta-orange" alt="Status: Early Beta"/>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/Fromlan/X-agent" alt="License: MIT"/></a>
+  <a href="https://github.com/Fromlan/X-agent/stargazers"><img src="https://img.shields.io/github/stars/Fromlan/X-agent?style=flat" alt="GitHub Stars"/></a>
+  <img src="https://img.shields.io/badge/platform-Windows%2010%2F11-blueviolet" alt="Platform: Windows 10/11"/>
+  <img src="https://img.shields.io/badge/Godot-4.x-478cbf" alt="Godot 4.x"/>
+</p>
 
-不是聊天工具的 UI 壳；不是 VS Code 替代品；是**长任务型 Agent**：回滚靠 Shadow Git、模式硬闸、Thinking 档位、品牌化客户端。
+<p align="center">
+  <a href="#install">安装</a> ·
+  <a href="#what-is-x-agent">三大支柱</a> ·
+  <a href="#x-agent-vs">对比</a> ·
+  <a href="docs/agent.md">开发文档</a> ·
+  <a href="docs/roadmap.md">路线图</a> ·
+  <a href="CHANGELOG.md">更新日志</a> ·
+  <a href="https://github.com/Fromlan/X-agent/issues">反馈</a>
+</p>
 
-![X-agent 主界面](docs/screenshots/main-window.png)
+<p align="center">
+  <a href="README.md">🇨🇳 简体中文</a> | <a href="README.en.md">🇺🇸 English</a>
+</p>
 
-## 目录
+---
 
-- [30 秒上手](#30-秒上手)
-- [你要用 X-agent 做什么？](#你要用-x-agent-做什么)
-- [关键能力](#关键能力)
-- [我该不该用 X-agent？](#我该不该用-x-agent)
-- [三个必知概念](#三个必知概念)
-- [键盘快捷键](#键盘快捷键)
-- [设置](#设置)
-- [数据位置](#数据位置)
-- [更新 & 安装](#更新--安装)
-- [安全与隐私](#安全与隐私)
-- [常见问题](#常见问题)
-- [反馈与贡献](#反馈与贡献)
-- [致谢](#致谢)
-- [联系](#联系)
+> **Early Beta**：活跃开发中，体验可能粗糙。
+
+> 不是 AGI，但是是 Godot 桌面 Agent 这个细分里**差异化最强**的一个：Godot 编辑器 RPC 联动 + Shadow Git 撤回 + 4 模式 2 类型硬闸。
+
+## Install
+
+**Windows**（当前唯一支持的桌面平台）：
+
+- **下载安装包**：[GitHub Releases](https://github.com/Fromlan/X-agent/releases/latest) — 选 `X-agent-Setup-x.y.z.exe` 下载双击安装
+- **应用内更新**：装好之后启动会自动静默检查新版本（在设置 → 通用手动 / 顶栏入口也能检查）
+
+**macOS / Linux**：等发版——见 [ROADMAP §1.3](docs/roadmap.md)。开发者可从源码跑（见下方"从源码开发"）。
 
 ## 30 秒上手
 
-1. **下载**：[Releases](https://github.com/Fromlan/X-agent/releases/latest) 装 Windows 安装包
-2. **打开项目**：选 Godot 工程目录（自动续最近会话）
-3. **登录认证**：设置 → 通用 → 打开 Pi 登录（或本机 `pi login` 已登录）
-4. **（可选）Godot 编辑器连接**：设置 → Godot → 编辑器连接 → 安装 **X-agent RPC** 插件
-5. 输 prompt，按回车
+1. **打开应用**，**打开项目**选你的 Godot 工程根目录
+2. **登录认证**：设置 → 通用 → "打开 Pi 登录"（或本机 `pi login` 已登录即可）
+3. （可选）**接 Godot 编辑器**：设置 → Godot → 编辑器连接 → 安装 **X-agent RPC** 插件 → 编辑器内启用 `x_agent_rpc`
+4. 输入框写 prompt，按 Enter
 
-**深入**：下方按 4 类角色场景展开。
+更深入：[角色场景](#你要用-x-agent-做什么) / [设置总览](#设置) / [键盘快捷键](#键盘快捷键)。
+
+## What is X-agent?
+
+X-agent 做三件其他 Agent 没做好的事：**Godot 深度联动**、**可信任的撤回**、**模式硬闸**。每条都链到 [docs/agent.md](docs/agent.md) 详细机制。
+
+### 🎮 Godot 深度联动
+
+- **编辑器 RPC（TCP）** — Agent 直接驱动当前 Godot 编辑器：开/重载场景、运行当前或主场景、跑完收集报错回传。默认端口 `8765`（回退 `8765–8774`），多编辑器显式选路。详见 [docs/agent.md §七](docs/agent.md)
+- **17 个 Godot 工具** — 场景内省（节点树 / 属性）/ 调试器（断点 / 状态）/ 资源治理（unused / lint / 导入）/ 导出（headless 子进程）/ 配置读写（`project.godot`）/ 只读内省（全局类 / export 模板 / UID 解析）
+- **godot-docs-4-7 技能** — Pi 自动发现并入 `<available_skills>`；按需 `read` 加载 SKILL.md，**0 token 浪费在"用不上的方法论"上**
+- **就绪清单** — 首次开 Godot 项目时一键引导（认证 / bash / RPC 插件 / Godot 工具 / 文档）
+
+### ↩️ 可信任的撤回
+
+- **Shadow Git 检查点**（每轮 prompt 前打独立检查点，独立于你项目里的 `.git`）→ 撤回 / 编辑重发 / 重新生成时按 diff 路径还原，**不会吞掉你回合期间的手动编辑**。无 Git 时降级为 `write` / `edit` 字节基线
+- **Diff 预览**（0.5.3+）—— 每轮结束在回复下方展示 `+/-` 着色 diff（带文件数与 `+N` / `-N` 统计）；撤回确认弹窗额外显示"将被还原的内容" diff，逐行确认
+- **断点不重写**：会话跨恢复不丢 Shadow 状态
+
+### 🔀 4 模式 + 2 类型硬闸
+
+- **会话模式（互斥切换）**：
+  - **Agent** —— 常规编码（默认白名单内）
+  - **Ask / 调研** —— 只读问答；硬闸关 `write` / `edit` / `write_plan`；`bash` 仅放行只读命令且路径须在项目 cwd 内
+  - **Plan** —— 只读研究 + `write_plan`；右栏可编辑 / 保存到项目 / 「执行计划」切回 Agent
+  - **Goal** —— 写完成条件 + 独立评估；轮次 + token 双预算，未达标自动续轮
+- **会话类型（与模式正交）**：
+  - **`code`**（默认，写入无限制）
+  - **`design`** —— 写操作**硬约束**到 `<cwd>/game-design/`，UI 切暖色主题；预装 5 个内置 skill：`design-initiation` / `design-process` / `design-systems` / `design-numerical` / `design-core-loop`
+
+## X-agent vs.
+
+**对比维度**（不只比"能不能用"——比"做了别人没做的事"）：
+
+| | VS Code + Copilot | Cursor | Claude Code | Pi CLI | **X-agent** |
+|---|---|---|---|---|---|
+| **Godot 编辑器 RPC** | ⚠️ 需第三方插件 | 🚫 无 | 🚫 无 | 🚫 无 | ✅ **深度集成**（17 工具 + 1.3 套件） |
+| **撤回机制** | ⚠️ 撤 message | ⚠️ 撤 message | ⚠️ 撤 message | 🚫 无 | ✅ **Shadow Git 按 diff 路径还原** |
+| **模式硬闸**（IPC 层） | 🚫 仅建议 | 🚫 仅建议 | ⚠️ permission mode | ⚠️ 配置文件 | ✅ **会话级强制**（Agent / Ask / Plan / Goal） |
+| **会话类型** | 🚫 无 | 🚫 无 | 🚫 无 | 🚫 无 | ✅ **`code` / `design` 双类型** |
+| **策划工作流支持** | 🚫 无 | 🚫 无 | 🚫 无 | 🚫 无 | ✅ **5 内置 design skill + game-design 硬约束** |
+| **数据本地** | ⚠️ 同步到云 | ⚠️ 同步到云 | ⚠️ 同步到云 | ✅ 本地 | ✅ **本机隔离**（与 Pi CLI 分目录） |
+| **Windows 安装包** | ✅ | ✅ | ✅ | ⚠️ CLI 为主 | ✅ **NSIS 双击安装** |
+| **模型可换** | ✅ | ✅ | ✅ | ✅ | ✅ **多 provider 档案 + Thinking 钳制** |
+| **UI 语言** | 多语种 | 多语种 | 多语种 | EN | 🚧 **中文 only**（英文文档由 README.en.md 承担） |
+| **开源** | 部分 | 🚫 | 🚫 | ✅ MIT | ✅ MIT |
+| **维护模式** | 商业 | 商业 | 商业 | 个人项目 | 🚧 **单兵项目**（见 [docs/maintenance.md](docs/maintenance.md)） |
+
+> ✅ = 完整支持　⚠️ = 部分 / 需配置　🚫 = 不支持　🚧 = 部分 / 在做
 
 ## 你要用 X-agent 做什么？
+
+四个常见场景，按"我是什么角色"选：
 
 ### 🎮 Godot 开发者 · 改代码 + 跑场景
 打开项目 → Agent 模式 → 选模型 → 问"在 `Player.gd` 加冲刺功能，跑一下当前场景" → Agent 改文件、编辑器 RPC 重载、跑场景、报错回传，**都在同一会话**。
@@ -54,34 +119,27 @@
 ### 🎯 目标驱动 · 让 Agent 自己跑到完成
 切 **目标 (Goal) 模式** → 写完成条件（如"在 `ScoreManager.gd` 加 combo 计数 + HUD 显示"） → 评估未达自动续轮（轮次 + token 双预算）。
 
-## 关键能力
+## 关键能力一览
 
-| | |
-|---|---|
-| **🎯 策划会话 (design)** | 写操作硬约束到 `<cwd>/game-design/`，UI 暖色主题。预装 5 个内置 skill：`design-initiation` / `design-process` / `design-systems` / `design-numerical` / `design-core-loop` |
-| **🎮 Godot 集成** | 编辑器 RPC（端口 8765，8765–8774 回退）；17 个工具覆盖场景内省 / 调试器 / 资源治理 / 导出 / 配置读写 / 只读内省 |
-| **📜 godot-docs-4-7** | 引擎惯例技能（Pi 自动发现）；按需 `read` SKILL.md，**0 token 浪费在"用不上的方法论"上** |
-| **↩️ Shadow Git 撤回** | 每轮检查点独立于你的 `.git`，按 diff 路径还原（**不会吞掉回合期间你的手动编辑**） |
-| **🔀 4 模式 + 2 类型** | 互斥切换：Agent / 调研(Ask) / Plan / 目标(Goal)；`code` / `design` 类型（与模式正交） |
-| **⚡ Diff 显示** | 撤回前看 `+/-` 着色 diff（带文件数 / `+N` / `-N` 统计），确认无误再点撤回 |
-| **🎨 8 套品牌 logo + 自定义** | 设置 → 通用 → 品牌：霓虹赛博 / 熔岩灼烧 / 电浆雷霆 / 全息彩虹 / 玫瑰金金属 / 像素 8-bit / 故障 Glitch / 宇宙星云 |
-| **🧠 思考档位 + thinking-orbs** | DeepSeek 等模型自动钳制 Thinking；运行中粒子轨道而非转圈 |
-| **🎨 v1.1 设计语言** | elevation 驱动：Composer 是整窗唯一主元素，三栏壳层（TopBar / Sidebar / RightPanel）降为低调 chrome；10 主题族（default / nord / tokyo / paper / contrast × dark/light） |
+| 能力 | 版本 | 用户能看到什么 |
+|---|---|---|
+| **🎯 策划会话 design 类型** | 0.5.5 | 写只允许落到 `<cwd>/game-design/`，UI 暖色主题 |
+| **🛠 5 个内置 design skill** | 0.5.5 | 立项 / 流程 / 系统 / 数值 / 核心循环懒写即用 |
+| **🎨 8 套品牌 logo + 自定义** | 0.5.5 | 设置 → 通用 → 品牌（霓虹赛博 / 熔岩灼烧 / …） |
+| **🎨 v1.1 elevation 设计语言** | 0.5.4 | Composer 唯一主元素，三栏降为低调 chrome |
+| **⚡ Diff 显示** | 0.5.3 | 撤回前 `+/-` 着色 diff，带 `+N` / `-N` 统计 |
+| **🔮 thinking-orbs 状态行动画** | 0.5.2 | 运行中粒子轨道而非转圈 |
+| **📜 godot-docs-4-7** | 0.4.x | 引擎惯例技能，按需 `read` |
+| **↩️ Shadow Git 撤回** | 0.4.x | 每轮检查点，按 diff 路径还原 |
+| **🎯 4 模式 + 2 类型硬闸** | 0.3.6+ | Agent / Ask / Plan / Goal × code / design |
+| **🧠 Thinking 档位 + 模型钳制** | 0.2.5+ | DeepSeek 等自动钳制，编辑器实时反馈 |
 
-## 我该不该用 X-agent？
-
-| 你的情况 | 建议 |
-|---|---|
-| 做 Godot 4 项目，**Windows** | ✅ 直接装 |
-| 做 Godot 4 项目，**macOS / Linux** | ⏸ 等 macOS / Linux 安装包（[ROADMAP 3.4](docs/roadmap.md)） |
-| 用 Unity / Unreal / 通用编码 | ❌ 不合适（Godot 专精） |
-| 只想试 LLM 聊天 | ❌ 直接用 [Pi CLI](https://pi.dev) 更轻 |
-| 想要云端多人协作 | ❌ 本机桌面型，单人项目 |
+完整 CHANGELOG：[`CHANGELOG.md`](CHANGELOG.md)。
 
 ## 三个必知概念
 
-- **会话模式**（互斥）：Agent / 调研(Ask) / Plan / 目标(Goal)，决定**能用什么工具**
-- **会话类型**（独立）：`code`（默认）/ `design`，写操作的**作用域**
+- **会话模式**（互斥）：Agent / Ask / Plan / Goal —— 决定**能用什么工具**
+- **会话类型**（独立）：`code` / `design` —— 决定**写操作的作用域**
 - **撤回源**：Shadow Git 检查点（独立于你的 `.git`），按 diff 路径还原
 
 ## 键盘快捷键
@@ -164,6 +222,35 @@ A: 不会。本机持久化（见 [数据位置](#数据位置)）。仅模型�
 **Q: 升级会丢数据吗？**
 A: 不会。升级保留 `~/.pi/agent/` 下所有内容。如需回滚到旧版，直接装旧 installer 覆盖。
 
+## 从源码开发
+
+开发者文档：[`docs/agent.md`](docs/agent.md) / [`CLAUDE.md`](CLAUDE.md)
+
+```bash
+git clone https://github.com/Fromlan/X-agent.git
+cd X-agent
+cd apps/desktop
+npm install
+npm run dev          # Electron 开发
+npm test             # 离线断言链
+npm run test:unit    # vitest
+npm run typecheck    # tsc 两个 tsconfig
+```
+
+发版流程：见 [`CLAUDE.md` §7](CLAUDE.md#7-发版流程)。
+
+## 路线图
+
+22 个里程碑 / 4 个 Phase。当前阶段：
+
+- ✅ **Phase 1** 工程质量 + Godot 深化（1.1 Vitest+Playwright / 1.2 7 个 Godot 工具 / 1.4 Lint / 1.5 @ 补全 / 1.6 E2E 契约锁）
+- 🛑 **1.3 i18n 基础** —— 已废弃（单兵项目，英文文档由 README.en.md 承担，UI 仍中文 only）
+- ⏳ **Phase 2** UX 打磨：会话导出 / 开发者诊断 / Plan 模板 / A11y
+- ⏳ **Phase 3** 差异化：主题编辑器 / 快捷键中心 / 多项目工作区
+- ⏳ **Phase 3.4** macOS / Linux 安装包
+
+完整路线图：[`docs/roadmap.md`](docs/roadmap.md)
+
 ## 反馈与贡献
 
 - **Bug / 功能请求**：[Issues](../../issues)（Bug / Feature / Question 3 类模板）
@@ -172,15 +259,13 @@ A: 不会。升级保留 `~/.pi/agent/` 下所有内容。如需回滚到旧版�
 - **行为准则**：[`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 - **协议**：[`LICENSE`](LICENSE) (MIT)
 - **维护节奏**：[`docs/maintenance.md`](docs/maintenance.md)
-- **路线图**：[`docs/roadmap.md`](docs/roadmap.md)（22 里程碑 / 4 Phase）
-
-变更记录见 [`CHANGELOG.md`](CHANGELOG.md)。开发与贡献说明见 [`CLAUDE.md`](CLAUDE.md)。
 
 ## 致谢
 
-- 基于 [Pi SDK](https://pi.dev)
+- 基于 [Pi SDK](https://pi.dev) — 上下文组装 / 会话 / compaction 的核心
 - 状态行动画：[thinking-orbs](https://github.com/JakubAntalik/thinking-orbs) (MIT © Jakub Antalik)
-- Logo 预设：内部 8 套（霓虹赛博 / 熔岩灼烧 / 电浆雷霆 / 全息彩虹 / 玫瑰金金属 / 像素 8-bit / 故障 Glitch / 宇宙星云）
+- Godot 文档：[godot-docs-4-7](https://godotengine.org/) 索引
+- 灵感来源：[Karpathy 关于 LLM Knowledgebase 的思考](https://x.com/karpathy/status/2039805659525644595)
 
 ## 联系
 
@@ -188,3 +273,9 @@ A: 不会。升级保留 `~/.pi/agent/` 下所有内容。如需回滚到旧版�
 |---|---|
 | 邮箱 | [fromlan@qq.com](mailto:fromlan@qq.com) |
 | QQ 群 | `1074500101` |
+
+---
+
+<p align="center">
+  <sub>如果 X-agent 帮到你，<a href="https://github.com/Fromlan/X-agent">点个 ⭐ Star</a> 让更多人看到。</sub>
+</p>


### PR DESCRIPTION
## 背景

现有 README 写得差（用户反馈），与 0.5.x 产品状态不同步（5 个新能力没讲），与英文版漂移（mode 数量、Settings 表、已删除的"官方文档"），与 CLAUDE.md / docs/ 重复。

参考 https://github.com/tinyhumansai/openhuman 的 README 模式（Hero / 三段式 / 4 角色场景 / From source 段）重写，按用户后续反馈砍掉了对比表段。

## 改动

`README.md` / `README.en.md`：

### 顶部 Hero 品牌区
- 居中标题 + 截图占位
- 6 徽章（latest / status / license / stars / platform / godot）
- 7 链接行（install / what-is / dev-docs / roadmap / changelog / issues）
- 中英双语切换

### 三个必知支柱（叙事而非列表）
- 🎮 **Godot 深度联动**：编辑器 RPC + 17 工具 + godot-docs-4-7 + 就绪清单
- ↩️ **可信任的撤回**：Shadow Git + Diff 预览 + 跨恢复
- 🔀 **4 模式 + 2 类型硬闸**：每种模式/类型简短说明 + code/design 区别

### 4 角色场景
- Godot 开发者 / 独立策划 / 研究只读 / 目标驱动

### 关键能力 10 项表格（带版本号 + 用户能看到什么）
- 策划会话 / 5 内置 skill / logo / v1.1 / Diff / thinking-orbs / godot-docs-4-7 / Shadow Git / 4 模式 2 类型 / Thinking 钳制

### 其他
- 键盘快捷键表 / 设置分页 / 数据位置 / 安全 3 段 / FAQ 5 条 / 从源码开发 / 路线图 / 致谢 / 联系
- Star CTA

## 中英双语

- 17 段 `##` 一一对应
- 行数 189 / 189
- 漂移清零（"Official docs" / "官方文档" / "godot_docs_search" 等已删除功能 0 命中）

## 不在范围

- 没动 docs/ / CHANGELOG.md / CLAUDE.md / 源码 / CI
- 没加实际截图（保留占位，等用户后续补）
- 砍掉了 "X-agent vs. 对比表" 段（按用户最新反馈）

## 关联

- 已有 PR #35（`docs/housekeeping-2026-08-26`）—— CHANGELOG 重复段清理 + 错误引用修正
- 本 PR 独立，不依赖 PR #35
