### PR TITLE
fix(session-mode): design-write-guard bash escape reason 用策划会话措辞

### DIFF
--- a/apps/desktop/electron/agent/session-mode/design-write-guard.test.ts
+++ b/apps/desktop/electron/agent/session-mode/design-write-guard.test.ts
@@ -262,7 +262,7 @@ describe("shouldBlockDesignSessionWrite — design session bash 约束", () => {
     expect(r.reason).toMatch(/策划会话/);
   });
 
-  it("试图 escape cwd: block", () => {
+  it("试图 escape cwd: block + reason 措辞是策划会话(不复用 plan-mode 措辞)", () => {
     const r = shouldBlockDesignSessionWrite(
       "design",
       "bash",
@@ -270,6 +270,10 @@ describe("shouldBlockDesignSessionWrite — design session bash 约束", () => {
       CWD,
     );
     expect(r.block).toBe(true);
+    expect(r.reason).toMatch(/策划会话/);
+    // 关键回归断言: design-write-guard 不能复用 plan-mode-guard 的
+    // "调研/Plan 模式" 措辞,否则用户在 agent 模式下看到会误判 mode。
+    expect(r.reason).not.toMatch(/调研\/Plan/);
   });
 });
 

--- a/apps/desktop/electron/agent/session-mode/design-write-guard.ts
+++ b/apps/desktop/electron/agent/session-mode/design-write-guard.ts
@@ -29,9 +29,7 @@ import { resolveInsideCwd } from "../cwd-sandbox";
 import { getReadablePluginRoots } from "../plugin-host";
 import {
   bashCommandEscapesCwd,
-  cwdEscapeBashBlockReason,
   isReadonlyBashCommand,
-  readonlyBashBlockReason,
 } from "./bash-readonly";
 
 /** Folder under cwd that the design session may write to. */
@@ -153,7 +151,7 @@ export function shouldBlockDesignSessionWrite(
     if (
       bashCommandEscapesCwd(command, cwd, getReadablePluginRoots(cwd))
     ) {
-      return { block: true, reason: cwdEscapeBashBlockReason(command) };
+      return { block: true, reason: designBashCwdEscapeBlockReason(command) };
     }
     return { block: false };
   }
@@ -215,6 +213,10 @@ function designBashBlockReason(command: string): string {
     `策划会话禁止执行写操作 bash 命令（${command.slice(0, 80)}）。` +
     `策划文档请用 write 工具写到 <cwd>/game-design/。`
   );
+}
+
+function designBashCwdEscapeBlockReason(command: string): string {
+  return `策划会话禁止 bash 访问项目目录外路径。已拦截：${command.slice(0, 120)}`;
 }
 
 /** Compatibility: exported for tests and downstream consumers. */


### PR DESCRIPTION
## 标题

fix(session-mode): design-write-guard bash escape reason 用策划会话措辞

## 变更摘要

design-write-guard 在 design session 下拦截 bash 越界时，复用了 plan-mode-guard 的 `cwdEscapeBashBlockReason`，文本写死「调研/Plan 模式禁止…」。结果在 **design session + agent 模式** 下用户收到这条拦截理由，会被误导以为自己身处 plan 模式。

本次为 design-write-guard 单独抽出 `designBashCwdEscapeBlockReason`，文本改为「策划会话禁止 bash 访问项目目录外路径」，与 design 会话语义对齐。

read-only bash block 走的设计本就有 `designBashBlockReason`，不再复用 plan 措辞，保持不动。

## 测试要点

- `design-write-guard.test.ts`：escape cwd 用例扩展为 reason 措辞回归断言
  - `expect(r.reason).toMatch(/策划会话/)`
  - `expect(r.reason).not.toMatch(/调研\/Plan/)` — 守住「不复用 plan 措辞」这个不变量
- `npm run typecheck` ✓
- `npm test`（vitest + 离线脚本全量）✓
- `npm run lint` ✓

## 影响面

- `apps/desktop/electron/agent/session-mode/design-write-guard.ts`：删除两个未用 / 误用的 import；新增 `designBashCwdEscapeBlockReason` helper
- `apps/desktop/electron/agent/session-mode/design-write-guard.test.ts`：强化 escape 用例的 reason 断言

## 回滚方案

直接 revert commit 即可。`cwdEscapeBashBlockReason` 本身保留在 `bash-readonly.ts`（plan-mode-guard 仍需要），只是 design-write-guard 不再调用它。
