### PR TITLE
feat: 优化策划模式 system prompt — 工具白名单 + GDD 标准骨架

### DIFF
--- a/apps/desktop/electron/agent/session-mode/controller.ts
+++ b/apps/desktop/electron/agent/session-mode/controller.ts
@@ -54,6 +54,7 @@ import {
 } from "./plan-journal";
 import {
   buildAskModeSystemAppend,
+  buildGameDesignLayoutGuide,
   buildGoalModeSystemAppend,
   buildPlanModeSystemAppend,
 } from "../../../shared/mode-prompt";
@@ -163,6 +164,12 @@ export class SessionModeController {
     const typeAppend = this.getSessionTypePolicy().systemAppend();
     if (typeAppend) {
       out.push(typeAppend);
+    }
+    // GDD layout guide (策划会话 only). Anchors the standard 9-section
+    // GDD skeleton so "整理 / 写入 设计文档" 任务不再产出 summary/audit/
+    // integration-plan 这类自由发挥的副产物 (#40 follow-up).
+    if (this.getSessionType() === "design") {
+      out.push(buildGameDesignLayoutGuide());
     }
     if (this.agentMode === "ask") {
       out.push(buildAskModeSystemAppend());

--- a/apps/desktop/electron/agent/session-mode/design-session-prompt.test.ts
+++ b/apps/desktop/electron/agent/session-mode/design-session-prompt.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Vitest 套件 —— SessionModeController.composeModeAppend 在 design session
+ * 下的 system append 注入行为 (#40 follow-up).
+ *
+ * 锁住 4 个不变量:
+ * 1. design session + 任意 mode → 注入 buildDesignSessionTypeAppend()
+ * 2. design session + 任意 mode → 追加 buildGameDesignLayoutGuide()
+ * 3. design session 注入的工具白名单出现 read/grep/find/ls/bash/write/edit
+ * 4. code session → 不注入 design append, 也不注入 GDD layout guide
+ *
+ * 通过 mock 一个最小 SessionModeHost (不依赖 Pi SDK) 来跑。
+ */
+import { describe, it, expect } from "vitest";
+import { SessionModeController } from "./controller";
+import type { SessionModeHost } from "./controller";
+import { DEFAULT_SESSION_TYPE, type SessionType } from "../../../shared/session-type";
+import type { AgentSession, DefaultResourceLoader, ModelRuntime } from "@earendil-works/pi-coding-agent";
+
+/** Build a minimal fake SessionModeHost for composeModeAppend-only tests. */
+function makeHost(opts: {
+  sessionType?: SessionType;
+  activeTools?: string[];
+  baseAppend?: string[];
+}): SessionModeHost {
+  const sessionType: SessionType = opts.sessionType ?? DEFAULT_SESSION_TYPE;
+  const activeTools = opts.activeTools ?? ["read", "write"];
+  const baseAppend = opts.baseAppend ?? [];
+  // Minimal AgentSession fake: only getActiveToolNames is touched by
+  // refreshSystemPrompt path; composeModeAppend itself does not call it.
+  const fakeSession = {
+    getActiveToolNames: () => activeTools,
+  } as unknown as AgentSession;
+  return {
+    getBundle: () => ({
+      session: fakeSession,
+      cwd: "D:/UGit/z-2",
+      sessionPath: null,
+      sessionType,
+    }),
+    getResourceLoader: () => null,
+    getBaseAppendPrompt: () => baseAppend,
+    emit: () => {},
+    emitReplaceableNotice: () => {},
+    prompt: async () => ({ ok: true as const }),
+    ensureRuntime: async () => ({}) as unknown as ModelRuntime,
+    getLastTurnTokenTotal: () => 0,
+    getActiveUserEntryId: () => null,
+  };
+}
+
+describe("SessionModeController.composeModeAppend — design session", () => {
+  it("design + agent mode: 注入 design append + GDD layout guide", () => {
+    const c = new SessionModeController(() => makeHost({ sessionType: "design" }));
+    const out = c.composeModeAppend([]);
+    const joined = out.join("\n\n");
+    // design append 标题
+    expect(joined).toContain("# X-agent Design session type");
+    // GDD layout guide 标题
+    expect(joined).toContain("# X-agent GDD layout guide");
+  });
+
+  it("design + agent mode: 8 个 design 工具名都出现 (read/grep/find/ls/bash/write/edit/godot_detect_project)", () => {
+    const c = new SessionModeController(() => makeHost({ sessionType: "design" }));
+    const out = c.composeModeAppend([]).join("\n");
+    for (const name of [
+      "`read`",
+      "`grep`",
+      "`find`",
+      "`ls`",
+      "`bash`",
+      "`write`",
+      "`edit`",
+      "`godot_detect_project`",
+    ]) {
+      expect(out).toContain(name);
+    }
+  });
+
+  it("design + agent mode: 不再含 'modes internally' 误导措辞 (#40 follow-up)", () => {
+    const c = new SessionModeController(() => makeHost({ sessionType: "design" }));
+    const out = c.composeModeAppend([]).join("\n");
+    expect(out).not.toMatch(/modes internally/);
+  });
+
+  it("design + plan mode: 同样注入 design append + GDD layout (与 4 mode 正交)", () => {
+    const c = new SessionModeController(() => makeHost({ sessionType: "design" }));
+    c.setMode("plan").catch(() => {});
+    const out = c.composeModeAppend([]).join("\n");
+    // plan mode 自身不进入 (write_plan 在 design tools 里没有, setMode 会失败回滚),
+    // 但 design session 的 type append 仍注入
+    expect(out).toContain("# X-agent Design session type");
+    expect(out).toContain("# X-agent GDD layout guide");
+  });
+
+  it("GDD layout guide 显式禁止 summary / audit / integration-plan 变体", () => {
+    const c = new SessionModeController(() => makeHost({ sessionType: "design" }));
+    const out = c.composeModeAppend([]).join("\n");
+    expect(out).toMatch(/summary\.md/);
+    expect(out).toMatch(/audit\.md/);
+    expect(out).toMatch(/integration-plan\.md/);
+  });
+});
+
+describe("SessionModeController.composeModeAppend — code session", () => {
+  it("code + agent mode: 不注入 design append 也不注入 GDD layout guide", () => {
+    const c = new SessionModeController(() => makeHost({ sessionType: "code" }));
+    const out = c.composeModeAppend([]).join("\n");
+    expect(out).not.toContain("# X-agent Design session type");
+    expect(out).not.toContain("# X-agent GDD layout guide");
+  });
+});

--- a/apps/desktop/shared/mode-prompt.test.ts
+++ b/apps/desktop/shared/mode-prompt.test.ts
@@ -7,9 +7,12 @@ import {
   ASK_MODE_INSTRUCTIONS,
   PLAN_MODE_INSTRUCTIONS,
   GOAL_MODE_INSTRUCTIONS,
+  DESIGN_SESSION_TYPE_INSTRUCTIONS,
   buildAskModeSystemAppend,
   buildPlanModeSystemAppend,
   buildGoalModeSystemAppend,
+  buildDesignSessionTypeAppend,
+  buildGameDesignLayoutGuide,
   wrapWithModeBlock,
   stripModeBlocks,
   modeBlockLabel,
@@ -80,5 +83,39 @@ describe("modeBlockLabel", () => {
     expect(modeBlockLabel("goal")).toBe("目标");
     expect(modeBlockLabel("build")).toBe("执行计划");
     expect(modeBlockLabel("")).toBe("mode");
+  });
+});
+
+describe("DESIGN_SESSION_TYPE_INSTRUCTIONS (v0.5+ rewrite)", () => {
+  it("白名单包含 read (avoid agent 跑去用 bash 读项目外路径)", () => {
+    expect(DESIGN_SESSION_TYPE_INSTRUCTIONS).toMatch(/`read`/);
+    expect(DESIGN_SESSION_TYPE_INSTRUCTIONS).toMatch(/`bash`/);
+  });
+
+  it("不再含 'modes internally' 措辞 (#40 follow-up 锁定的回归点)", () => {
+    expect(DESIGN_SESSION_TYPE_INSTRUCTIONS).not.toMatch(/modes internally/);
+  });
+
+  it("buildDesignSessionTypeAppend 带标题 + 内容非空", () => {
+    const out = buildDesignSessionTypeAppend();
+    expect(out.startsWith("# X-agent Design session type")).toBe(true);
+    expect(out.length).toBeGreaterThan(200);
+  });
+});
+
+describe("buildGameDesignLayoutGuide", () => {
+  it("至少含 '主设计文档' GDD 关键词", () => {
+    expect(buildGameDesignLayoutGuide()).toMatch(/主设计文档/);
+  });
+
+  it("再次锚定 game-design/ 路径约束 (避免 LLM 写到散落位置)", () => {
+    expect(buildGameDesignLayoutGuide()).toMatch(/game-design\//);
+  });
+
+  it("显式禁止 summary / audit / integration-plan 变体 (本次对话 agent 的实际错误路径)", () => {
+    const guide = buildGameDesignLayoutGuide();
+    expect(guide).toMatch(/summary\.md/);
+    expect(guide).toMatch(/audit\.md/);
+    expect(guide).toMatch(/integration-plan\.md/);
   });
 });

--- a/apps/desktop/shared/mode-prompt.ts
+++ b/apps/desktop/shared/mode-prompt.ts
@@ -59,21 +59,92 @@ export function buildGoalModeSystemAppend(condition: string): string {
  * Design session type system append. Injected BEFORE the mode-level append
  * (ask/plan/goal) so the type constraint is always visible. Appended only
  * when the active SessionType is "design".
+ *
+ * v0.5+: Rewritten after a real failure (issue #40 follow-up). The previous
+ * version said "You may use ask/plan/agent/goal modes internally" — that
+ * phrasing made the LLM think there was an inner sub-mode, which leaked
+ * plan-mode error messages into agent-mode behavior. New version:
+ *   - states identity first (orthogonal to the 4 modes)
+ *   - lists tools by name (whitelist > blacklist; LLM defaults to "anything
+ *     not banned is allowed")
+ *   - explicitly calls out cross-cwd read access so the agent doesn't waste
+ *     turns trying `bash ls ../design` to read sibling project assets
  */
 export const DESIGN_SESSION_TYPE_INSTRUCTIONS = [
-  "You are in a Design session: produce structured game design documents.",
-  "Read: any project file (you can navigate the existing code as a reference).",
-  "Write: only inside <cwd>/game-design/ — markdown documents, data tables, or config snippets for design assets.",
-  "Do NOT use write/edit/bash to modify game code, scenes, project.godot, or any file outside game-design/.",
-  "If the user asks for code changes, tell them to open a Code session (新代码会话) — do not attempt to mutate code in this session.",
-  "You may use ask/plan/agent/goal modes internally; the game-design write constraint is always active regardless of mode.",
-  "write_plan is disabled in this session: write design documents directly into <cwd>/game-design/ instead of plan files.",
+  "You are in a Design session (策划会话). The 4 modes (ask/plan/agent/goal) share the same design tool set — switching mode does not unlock new tools or lift the game-design/ write constraint.",
+  "Available tools in this session: `read`, `grep`, `find`, `ls`, `bash` (read-only commands only; path must stay inside project cwd), `write` (path must be inside `<cwd>/game-design/`), `edit` (same constraint), `godot_detect_project`.",
+  "Disabled in this session: `write_plan` (策划文档直接写到 `<cwd>/game-design/`，不走 plan 流程); `godot_set_project_setting` and other unlisted Godot mutating tools are blocked by the design-write-guard. If the user wants code changes, tell them to open a Code session (新代码会话).",
+  "Cross-project reference: 策划需要参考其他项目的设计资产时, 可以用 `read` / `grep` / `find` / `ls` 直接读**项目外任意路径** (这些 read 系列工具不受 design-write-guard 限制), 但**不要用 bash 访问项目外路径** — bash 的 cwd sandbox 会拦截.",
+  'Writing GDD: when the user says "整理 / 写入" 设计文档, follow the standard GDD skeleton (see layout guide below). Do NOT produce a summary.md / audit.md / integration-plan.md / engine-*.md unless the user explicitly asks.',
 ].join("\n");
 
 export function buildDesignSessionTypeAppend(): string {
   return ["# X-agent Design session type", DESIGN_SESSION_TYPE_INSTRUCTIONS].join(
     "\n",
   );
+}
+
+/**
+ * GDD 布局引导 —— 给"整理/写入设计文档"任务列标准子模块。
+ * 由 controller.composeModeAppend 在 design session 追加在 type append 之后。
+ *
+ * 设计取舍: 不强制 agent 全写 (不同策划阶段需要的 GDD 子集不同),
+ * 但显式禁止 summary/audit/integration-plan 这 4 个变体 — 那是
+ * #40 follow-up 对话里 agent 的实际错误路径。
+ */
+export function buildGameDesignLayoutGuide(): string {
+  const sections = [
+    {
+      name: "01-主设计文档.md",
+      purpose: "游戏总纲: 一句话定位、核心循环、设计支柱、9 个核心系统 (棋子/羁绊/经济/爬塔/法宝/战斗/建筑/峰/难度)",
+    },
+    {
+      name: "02-棋子图鉴.md",
+      purpose: "每个棋子的属性、技能、定位、speed 档位 (如适用, 也叫'角色图鉴')",
+    },
+    {
+      name: "03-羁绊效果.md",
+      purpose: "羁绊/职业/种族的激活条件、数值、Combo 表",
+    },
+    {
+      name: "04-法宝图鉴.md",
+      purpose: "装备/法宝的触发、效果、合成 (如适用, 也叫'装备图鉴')",
+    },
+    {
+      name: "05-建筑数值.md",
+      purpose: "建筑/城池/基地的升级、产出、玩家等级",
+    },
+    {
+      name: "06-敌人阵容.md",
+      purpose: "敌方单位、阵容、难度梯度、Boss 列表",
+    },
+    {
+      name: "07-峰的选择.md",
+      purpose: "玩家初始身份/种族/职业的独特加成、初始棋子、克制链 (如适用, 也叫'职业选择'/'出身选择')",
+    },
+    {
+      name: "08-事件奇遇.md",
+      purpose: "随机/分支事件、道德/善恶系统、事件链",
+    },
+    {
+      name: "09-章节与Boss.md",
+      purpose: "主线/关卡流程、Boss 技能、章节奖励",
+    },
+  ];
+  const header = [
+    "# X-agent GDD layout guide (策划会话)",
+    "",
+    'When the user says "整理 / 写入" 设计文档 to `<cwd>/game-design/`, write one markdown file per row below. Use 1 行文件名 + 1 行问题说明 + 实际内容 (具体数值/列表/效果).',
+    "",
+    "如果项目已有自己的命名 (比如'角色'替代'棋子', '出身'替代'峰'), 沿用项目约定; 文件名里那一截也可以替换。",
+    "",
+    "Do NOT produce a summary.md / audit.md / integration-plan.md / engine-*.md unless the user explicitly asks. 不要把原始策划案**逐字复制**过来当成 game-design/ 的内容 — 整理的意思是按下面的骨架写。",
+    "",
+  ].join("\n");
+  const body = sections
+    .map((s) => `- **${s.name}** — ${s.purpose}`)
+    .join("\n");
+  return header + body;
 }
 
 export function wrapWithModeBlock(


### PR DESCRIPTION
## 标题

feat: 优化策划模式 system prompt — 工具白名单 + GDD 标准骨架

## 背景

对话 `01a04c8f-1e43-7786-9e79-aeb06b811c7f.jsonl`（#40 修复后复现）暴露两个问题：

1. **agent 一开始不知道自己在 design session**：默认用 `bash` 跑 `ls "D:/UGit/自走棋/design"`，被 design-write-guard 拦截 2 次后才意识到「bash 不可用，read 可以」，浪费 2 轮 round-trip。
2. **「把内容整理后写到 `<cwd>/game-design/` 下」任务，agent 实际写出 4 份副产物**（README / 00-design-summary / engine-integration-plan / design-audit），完全缺 9 份 GDD（主设计 + 棋子/羁绊/法宝/建筑/敌人/峰/事件/章节）。用户原话："整理出的文件太乱，没有游戏设计文档，还多出一个 readme"。

## 根因

`DESIGN_SESSION_TYPE_INSTRUCTIONS` 7 行文案在 `apps/desktop/shared/mode-prompt.ts:63-71`：

- 第 6 行 `"You may use ask/plan/agent/goal modes internally"` — 让 LLM 误以为有"内部 sub-mode"概念，是 #40 排查时锁定的语义噪声
- 第 4 行 `"Do NOT use write/edit/bash..."` 用禁止语而非白名单语，LLM 默认"剩下都能用"
- 完全没有"游戏设计文档的标准骨架"，agent 自由发挥

## 改动

按 plan 切 2 个 commit：

### commit 1 — `feat(mode-prompt)` (5b05642)

- `DESIGN_SESSION_TYPE_INSTRUCTIONS` 重写为 5 段：身份 / 工具白名单（8 个工具名直接列出）/ 黑名单（write_plan / godot_set_*）/ 跨目录读（read 系列可读项目外，bash 不行）/ GDD 整理任务（指向 layout guide）
- 新增 `buildGameDesignLayoutGuide()` helper：列 9 份标准 GDD 子模块（主设计 + 9 个子系统），每条 1 行用途说明；显式禁止 summary/audit/integration-plan 变体
- `mode-prompt.test.ts` 加 3 个不变量断言（白名单 / 不再含 "modes internally" / GDD layout 引导关键词）

### commit 2 — `feat(session-mode)` (e9dce28)

- `composeModeAppend` 在 type append 之后追加 `buildGameDesignLayoutGuide()` 输出，**仅当** `getSessionType() === "design"`
- 新增 `design-session-prompt.test.ts` mock 最小 SessionModeHost，验证 6 个不变量（design 注入 / 8 工具 / 不再含 "modes internally" / plan mode 也注入 / 禁止副产物 / code session 不注入）

## 注入顺序

```
[base...] → [design type append] → [GDD layout guide] → [ask/plan/goal append if any]
```

## 影响面

- `apps/desktop/shared/mode-prompt.ts` — `DESIGN_SESSION_TYPE_INSTRUCTIONS` 重写 + 新增 `buildGameDesignLayoutGuide()`
- `apps/desktop/shared/mode-prompt.test.ts` — 加 3 个 describe 区
- `apps/desktop/electron/agent/session-mode/controller.ts` — `composeModeAppend` 加 GDD layout 注入
- `apps/desktop/electron/agent/session-mode/design-session-prompt.test.ts` — 新文件

## 不动

- `plan-mode-guard` / `design-write-guard` / `bash-readonly` — 拦截行为已在 #40 修过
- `DESIGN_SESSION_TYPE_TOOLS` — 是事实，不动
- `controller.setMode` — 不动
- `DesignPolicy.systemAppend()` — 保持纯 string，组合在 controller 负责

## 验收

- `npm run typecheck` ✓
- `npm test` (vitest + 离线脚本全量) ✓
- `npm run lint` ✓
- mode-prompt.test.ts 16 passed
- design-session-prompt.test.ts 6 passed

端到端验收（手工跑）放在 #40 后的真实用户场景：

1. agent 第一反应不再调 bash 跑 `D:/UGit/自走棋/design`，应直接 `read` 工具读 `00-INDEX.md`
2. 「把内容整理后写到 game-design/」任务：agent 写出 ≥ 5 份 MD，至少包含 1 份 `01-主设计文档.md`；不再有 `summary.md` / `audit.md` / `integration-plan.md` / `engine-*.md` 副产物
3. CSV 拷到 game-design/ 任务：agent 直接 read CSV → write 到 game-design/，不再用 bash `cp`

## 回滚方案

直接 revert commit 即可。`composeModeAppend` 的 GDD layout 注入独立于文案，可单独 revert commit 2。

## 相关 issue / PR

- #40: design-write-guard bash escape reason 措辞（已 merge）
- 本次 PR: #40 的 follow-up
