### PR TITLE
feat(attachments): composer 粘贴截图与拖放文件（绝对路径 + chip 化）

### DIFF
--- a/apps/desktop/electron/agent/session-host.ts
+++ b/apps/desktop/electron/agent/session-host.ts
@@ -21,6 +21,7 @@ import {
   type OpenProjectResult,
   type PlanContentResult,
   type PlanMutateResult,
+  type PromptPayload,
   type PromptResult,
   type RetractOptions,
   type RetractPreview,
@@ -198,7 +199,7 @@ export class SessionHost {
       emit: (event) => this.emit(event),
       emitReplaceableNotice: (replaceKey, text, level) =>
         this.emitReplaceableNotice(replaceKey, text, level),
-      prompt: (text) => this.prompt(text),
+      prompt: (text) => this.prompt({ text }),
       ensureRuntime: () => this.ensureRuntime(),
       getLastTurnTokenTotal: () => this.lastTurnUsage?.tokens.total ?? 0,
       getActiveUserEntryId: () => this.fileTracker.getActiveUserEntryId(),
@@ -214,7 +215,7 @@ export class SessionHost {
       pruneToolDetailsToBranch: () => this.pruneToolDetailsToBranch(),
       emitHistoryReplace: () => this.emitHistoryReplace(),
       emitUsageUpdate: () => this.emitUsageUpdate(),
-      prompt: (text) => this.prompt(text),
+      prompt: (text) => this.prompt({ text }),
       isPromptPreparing: () => this.promptPreparing,
       onRetractSuccess: (abandonedUserEntryIds) =>
         this.sessionMode.rollbackGoalAfterRetract(abandonedUserEntryIds),
@@ -741,21 +742,23 @@ export class SessionHost {
     return this.lifecycle.dispose();
   }
 
-  async prompt(text: string): Promise<PromptResult> {
+  async prompt(payload: PromptPayload): Promise<PromptResult> {
     const bundle = this.bundle;
     if (!bundle) {
       dbgLog("session", "prompt rejected: no bundle");
       return { ok: false, error: "尚未打开项目" };
     }
-    const trimmed = text.trim();
-    if (!trimmed) {
-      dbgLog("session", "prompt rejected: empty text");
+    const text = (payload?.text ?? "").trim();
+    const images = payload?.images;
+    if (!text && (!images || images.length === 0)) {
+      dbgLog("session", "prompt rejected: empty text and no images");
       return { ok: false, error: "消息不能为空" };
     }
 
     dbgLog("session", "prompt start", {
-      len: trimmed.length,
-      preview: trimmed.slice(0, 80),
+      len: text.length,
+      preview: text.slice(0, 80),
+      imageCount: images?.length ?? 0,
       isStreaming: bundle.session.isStreaming,
     });
     const doneShadow = dbgTimer("session", "preparePromptCheckpoint");
@@ -764,8 +767,8 @@ export class SessionHost {
 
     try {
       const { session } = bundle;
-      const slashName = trimmed.startsWith("/")
-        ? (trimmed.match(/^\/([^\s]+)/)?.[1] ?? "")
+      const slashName = text.startsWith("/")
+        ? (text.match(/^\/([^\s]+)/)?.[1] ?? "")
         : "";
       const isExtensionCommand =
         Boolean(slashName) &&
@@ -774,9 +777,9 @@ export class SessionHost {
 
       // Wrap prompt templates as `<prompt>` so the UI can chip them
       // (Pi already wraps `/skill:name` as `<skill>`).
-      let sendText = trimmed;
+      let sendText = text;
       if (!isExtensionCommand) {
-        const wrapped = wrapPromptSlashAsBlock(trimmed, [
+        const wrapped = wrapPromptSlashAsBlock(text, [
           ...session.promptTemplates,
         ]);
         if (wrapped) sendText = wrapped;
@@ -784,7 +787,7 @@ export class SessionHost {
 
       if (session.isStreaming) {
         dbgLog("session", "prompt: steer into active stream");
-        await session.prompt(sendText, { streamingBehavior: "steer" });
+        await session.prompt(sendText, { streamingBehavior: "steer", images });
         donePi();
       } else {
         dbgLog("session", "prompt: prepare shadow checkpoint…");
@@ -802,7 +805,7 @@ export class SessionHost {
           dbgLog("session", "prompt aborted: bundle switched during shadow");
           return { ok: false, error: "会话已切换" };
         }
-        await session.prompt(sendText);
+        await session.prompt(sendText, { images });
         donePi();
       }
       if (this.bundle !== bundle) {

--- a/apps/desktop/electron/ipc/register-turn-ipc.ts
+++ b/apps/desktop/electron/ipc/register-turn-ipc.ts
@@ -1,6 +1,7 @@
 import type { IpcMain } from "electron";
 import type { SessionHost } from "../agent/session-host";
 import { IPC_CHANNELS } from "../../shared/ipc-channels";
+import type { PromptPayload } from "../../shared/ipc";
 import { dbgLog, dbgTimer } from "../../shared/debug-log";
 import { handle } from "./register-ipc";
 
@@ -13,14 +14,18 @@ export function registerTurnIpc(
   ipcMain: IpcMain,
   sessionHost: SessionHost,
 ): void {
-  handle(ipcMain, IPC_CHANNELS.prompt, async (_e, text: string) => {
+  handle(ipcMain, IPC_CHANNELS.prompt, async (_e, payload: PromptPayload) => {
+    const text = payload?.text ?? "";
     if (typeof text !== "string" || text.length > PROMPT_MAX_LENGTH) {
       return { ok: false, error: `消息过长（上限 ${PROMPT_MAX_LENGTH} 字符）` };
     }
-    dbgLog("ipc", "prompt handler entered", { len: text?.length });
+    dbgLog("ipc", "prompt handler entered", {
+      len: text.length,
+      imageCount: payload?.images?.length ?? 0,
+    });
     const done = dbgTimer("ipc", "prompt handler");
     try {
-      const result = await sessionHost.prompt(text);
+      const result = await sessionHost.prompt(payload);
       done();
       dbgLog("ipc", "prompt handler result", { ok: result.ok, silent: result.silent, error: result.error });
       return result;

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from "electron";
+import { contextBridge, ipcRenderer, webUtils } from "electron";
 import { DELETED_FLAT_KEYS } from "../shared/ipc";
 import type {
   AppUpdateStatus,
@@ -184,3 +184,18 @@ const exposed: XAgentApi = {
 } as XAgentApi;
 
 contextBridge.exposeInMainWorld("xAgent", exposed);
+
+// Drag-and-drop helper: Electron 32+ no longer augments File with `.path`
+// (security: cross-origin drag). Renderer 进程需要走 webUtils.getPathForFile
+// 拿绝对路径, 用于 @<path> 引用 / cwd-sandbox resolve. Expose it via
+// contextBridge so the sandboxed renderer can call it without importing
+// 'electron' directly.
+contextBridge.exposeInMainWorld("xAgentPath", {
+  getForFile: (file: File): string => {
+    try {
+      return webUtils.getPathForFile(file);
+    } catch {
+      return "";
+    }
+  },
+});

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -6,6 +6,7 @@ import type {
   FlatInvokeApi,
   IpcChannelKey,
   IpcInvokeMap,
+  PromptPayload,
   UiAgentEvent,
   XAgentApi,
   XAgentApiFlat,
@@ -36,10 +37,13 @@ function makeInvokeApi(): FlatInvokeApi {
 const api = makeInvokeApi();
 
 // Channel-keyed methods that keep custom logging on the renderer side.
-api.prompt = ((text: string) => {
-  dbgLog("preload", "invoke prompt", { len: text?.length, preview: text?.slice(0, 80) });
+api.prompt = ((payload: PromptPayload) => {
+  dbgLog("preload", "invoke prompt", {
+    textLen: payload?.text?.length,
+    imageCount: payload?.images?.length ?? 0,
+  });
   const done = dbgTimer("preload", "prompt roundtrip");
-  return ipcRenderer.invoke(IPC_CHANNELS.prompt, text).then((result) => {
+  return ipcRenderer.invoke(IPC_CHANNELS.prompt, payload).then((result) => {
     done();
     dbgLog("preload", "prompt result", result);
     return result;

--- a/apps/desktop/shared/ipc.test.ts
+++ b/apps/desktop/shared/ipc.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Vitest 套件 —— shared/ipc 的核心 payload 类型契约。
+ *
+ * 锁住 4 个不变量 (#42 composer attachments 的 IPC 形状):
+ * 1. PromptPayload.text 必填 (可空字符串, 配合 images-only 发图)
+ * 2. PromptPayload.images 可选, 缺省 = 仅 text
+ * 3. ImageContent.data 是 base64 字符串, mimeType 是字符串
+ * 4. IpcInvokeMap.prompt 接受 PromptPayload, 返回 Promise<PromptResult>
+ *
+ * 不验证运行时行为 (那是 session-host.test.ts 的责任); 这里只
+ * 验证类型在编译期可序列化、字段不漏。
+ */
+import { describe, it, expect } from "vitest";
+import type { ImageContent, PromptPayload, PromptResult } from "./ipc";
+
+describe("PromptPayload 形状", () => {
+  it("text 必填 (允许空字符串, 由 images 承担消息)", () => {
+    const payload: PromptPayload = { text: "" };
+    expect(payload.text).toBe("");
+    expect(payload.images).toBeUndefined();
+  });
+
+  it("images 可选, 缺省时仅 text", () => {
+    const payload: PromptPayload = { text: "hello" };
+    expect(payload.images).toBeUndefined();
+  });
+
+  it("images 数组可以非空, data 是 base64, mimeType 是字符串", () => {
+    const img: ImageContent = {
+      type: "image",
+      data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+      mimeType: "image/png",
+    };
+    const payload: PromptPayload = { text: "see attached", images: [img] };
+    expect(payload.images).toHaveLength(1);
+    expect(payload.images![0]!.data.length).toBeGreaterThan(0);
+    expect(payload.images![0]!.mimeType).toBe("image/png");
+  });
+
+  it("JSON 序列化无损 round-trip (模拟 IPC 跨进程传递)", () => {
+    const original: PromptPayload = {
+      text: "看看这张图",
+      images: [
+        { type: "image", data: "abc", mimeType: "image/jpeg" },
+      ],
+    };
+    const json = JSON.stringify(original);
+    const parsed = JSON.parse(json) as PromptPayload;
+    expect(parsed.text).toBe("看看这张图");
+    expect(parsed.images).toHaveLength(1);
+    expect(parsed.images![0]!.mimeType).toBe("image/jpeg");
+    expect(parsed.images![0]!.data).toBe("abc");
+  });
+});
+
+describe("PromptResult 形状", () => {
+  it("ok / error / silent 三态", () => {
+    const ok: PromptResult = { ok: true };
+    const fail: PromptResult = { ok: false, error: "消息不能为空" };
+    const silent: PromptResult = { ok: true, silent: true };
+    expect(ok.ok).toBe(true);
+    expect(fail.error).toBe("消息不能为空");
+    expect(silent.silent).toBe(true);
+  });
+});

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -585,6 +585,34 @@ export interface PromptResult {
   silent?: boolean;
 }
 
+/**
+ * Image attachment for a prompt. Mirrors the shape of Pi SDK's
+ * `ImageContent` (declared in `@earendil-works/pi-ai/dist/types.d.ts`)
+ * but lives in `shared/` so the renderer never has to import the
+ * Pi SDK type directly — keeps the renderer bundle free of
+ * `@earendil-works/pi-ai`.
+ *
+ * The data is the base64-encoded image body (no `data:` URL prefix).
+ * mimeType must be one of the supported image types; the renderer
+ * enforces the whitelist at attachment time.
+ */
+export interface ImageContent {
+  type: "image";
+  data: string;
+  mimeType: string;
+}
+
+/**
+ * Payload for the renderer → main `prompt` IPC. `text` is required
+ * but may be empty when `images` carries the message (e.g. paste a
+ * screenshot with no caption). main-side rejects the call when both
+ * are empty.
+ */
+export interface PromptPayload {
+  text: string;
+  images?: ImageContent[];
+}
+
 /** Serializable chat history item shared by main ↔ renderer. */
 export type HistoryItem =
   | { kind: "user"; id: string; text: string; entryId?: string }
@@ -1284,7 +1312,7 @@ export type GodotApi = {
  */
 export type IpcInvokeMap = {
   openProject: (path?: string, mode?: OpenProjectMode) => Promise<OpenProjectResult>;
-  prompt: (text: string) => Promise<PromptResult>;
+  prompt: (payload: PromptPayload) => Promise<PromptResult>;
   abort: () => Promise<{ ok: boolean }>;
   previewRetract: (entryId: string) => Promise<RetractPreview>;
   retractToUserMessage: (entryId: string, options?: RetractOptions) => Promise<RetractResult>;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -494,13 +494,9 @@ export default function App() {
       setAttachments((prev) => [...prev, ...images]);
     }
     if (references.length > 0) {
-      // Input 文本只显示短串 (📎 <basename>), 绝对路径单独存
-      // fileRefs state, send 时拼到 user message 末尾 (走
-      // expandAtPaths 展开成 <file> 块). 这样 composer 短, AI
-      // 拿到完整路径.
-      setInput((prev) =>
-        prev + references.map((r) => `📎 ${r.displayName} `).join(""),
-      );
+      // 文件不进 input 文本 —— 由 ComposerAttachments 渲染成 chip
+      // (跟图片附件同区域). 绝对路径存 fileRefs state, send 时
+      // 走 expandAtPaths 展开成 <file> 块拼到 user message 末尾.
       setFileRefs((prev) => [...prev, ...references]);
     }
     if (notices.length > 0) {
@@ -508,8 +504,12 @@ export default function App() {
     }
   }, []);
 
-  const onRemoveAttachment = useCallback((index: number) => {
+  const onRemoveImage = useCallback((index: number) => {
     setAttachments((prev) => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const onRemoveFile = useCallback((index: number) => {
+    setFileRefs((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
   const onSessionModeChange = useCallback(
@@ -1214,8 +1214,10 @@ export default function App() {
           onSend={send}
           onAbort={abort}
           attachments={attachments}
+          fileRefs={fileRefs}
           onAddFiles={onAddFiles}
-          onRemoveAttachment={onRemoveAttachment}
+          onRemoveImage={onRemoveImage}
+          onRemoveFile={onRemoveFile}
           disabled={!cwd}
           skillsRefreshKey={`${cwd ?? ""}:${sessionId ?? ""}`}
           queuedSteering={queuedSteering}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -16,6 +16,7 @@ import type {
   ClientPrefs,
   GitCheckResult,
   GoalInfo,
+  ImageContent,
   ModelInfo,
   PiCliStatus,
   PrefsRecoveryNotice,
@@ -52,6 +53,7 @@ import {
   collapseFileBlocksToAtPaths,
   expandAtPathsInPrompt,
 } from "./lib/expandAtPaths";
+import { splitFilesForAttachment } from "./lib/file-attachment";
 import { startersForProject } from "./lib/chat-starters";
 import { allGodotEditorToolsEnabled } from "./lib/ready-checklist";
 import {
@@ -110,6 +112,7 @@ export default function App() {
   const [piCliInstalling, setPiCliInstalling] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [input, setInput] = useState("");
+  const [attachments, setAttachments] = useState<ImageContent[]>([]);
   const [busy, setBusy] = useState(false);
   const [sessionMode, setSessionMode] = useState<AgentSessionMode>("agent");
   const [sessionType, setSessionType] = useState<SessionType>(DEFAULT_SESSION_TYPE);
@@ -367,7 +370,11 @@ export default function App() {
       return;
     }
     const text = input.trim();
+    // Snapshot attachments before clearing input so we can pass them
+    // into the IPC payload. Cleared below to keep empty state on send.
+    const currentAttachments = attachments;
     setInput("");
+    setAttachments([]);
     setError(null);
     setFollowNonce((n) => n + 1);
     dbgLog("chat", "send invoked", { len: text.length, preview: text.slice(0, 80), status, sessionMode });
@@ -438,7 +445,10 @@ export default function App() {
     const expanded = await expandAtPathsInPrompt(text);
     doneExpand();
     const doneRoundtrip = dbgTimer("chat", "window.xAgent.turn.prompt roundtrip");
-    const result = await window.xAgent.turn.prompt({ text: expanded });
+    const result = await window.xAgent.turn.prompt({
+      text: expanded,
+      images: currentAttachments.length > 0 ? currentAttachments : undefined,
+    });
     doneRoundtrip();
     dbgLog("chat", "turn.prompt resolved", { ok: result.ok, silent: result.silent, error: result.error });
     if (!result.ok || result.silent) {
@@ -446,7 +456,30 @@ export default function App() {
       if (!result.ok) setError(result.error ?? "发送失败");
     }
     await refreshSessions();
-  }, [input, cwd, sessionMode, goal, refreshSessions, status]);
+  }, [input, attachments, cwd, sessionMode, goal, refreshSessions, status]);
+
+  /**
+   * Composer 拖文件 / 粘贴文件时调用. 分类为图片 (入 attachments) 和
+   * 非图片 (拼 @<path> 引用到 input 文本, 走现有 expandAtPaths 路径).
+   * notices 推给 setError 横幅.
+   */
+  const onAddFiles = useCallback(async (files: File[]) => {
+    if (files.length === 0) return;
+    const { images, references, notices } = await splitFilesForAttachment(files);
+    if (images.length > 0) {
+      setAttachments((prev) => [...prev, ...images]);
+    }
+    if (references.length > 0) {
+      setInput((prev) => prev + references.join(""));
+    }
+    if (notices.length > 0) {
+      setError(notices.join("\n"));
+    }
+  }, []);
+
+  const onRemoveAttachment = useCallback((index: number) => {
+    setAttachments((prev) => prev.filter((_, i) => i !== index));
+  }, []);
 
   const onSessionModeChange = useCallback(
     async (mode: AgentSessionMode) => {
@@ -1149,6 +1182,9 @@ export default function App() {
           setInput={setInput}
           onSend={send}
           onAbort={abort}
+          attachments={attachments}
+          onAddFiles={onAddFiles}
+          onRemoveAttachment={onRemoveAttachment}
           disabled={!cwd}
           skillsRefreshKey={`${cwd ?? ""}:${sessionId ?? ""}`}
           queuedSteering={queuedSteering}

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -465,7 +465,21 @@ export default function App() {
    */
   const onAddFiles = useCallback(async (files: File[]) => {
     if (files.length === 0) return;
-    const { images, references, notices } = await splitFilesForAttachment(files);
+    // 走 preload 暴露的 webUtils.getPathForFile 拿绝对路径
+    // (Electron 32+ 不再自动挂 .path). webUtils 在 renderer 是
+    // contextBridge 沙箱外的, 仅 preload 能 import; 我们通过
+    // window.xAgentPath.getForFile 间接调用.
+    const pathGetter = window.xAgentPath?.getForFile;
+    const items = files.map((file) => {
+      let absPath = "";
+      try {
+        absPath = pathGetter ? pathGetter(file) : "";
+      } catch {
+        absPath = "";
+      }
+      return { file, absPath, fallbackName: file.name };
+    });
+    const { images, references, notices } = await splitFilesForAttachment(items);
     if (images.length > 0) {
       setAttachments((prev) => [...prev, ...images]);
     }

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -438,7 +438,7 @@ export default function App() {
     const expanded = await expandAtPathsInPrompt(text);
     doneExpand();
     const doneRoundtrip = dbgTimer("chat", "window.xAgent.turn.prompt roundtrip");
-    const result = await window.xAgent.turn.prompt(expanded);
+    const result = await window.xAgent.turn.prompt({ text: expanded });
     doneRoundtrip();
     dbgLog("chat", "turn.prompt resolved", { ok: result.ok, silent: result.silent, error: result.error });
     if (!result.ok || result.silent) {
@@ -733,7 +733,7 @@ export default function App() {
       const pendingId = makePendingUserId();
       setItems((prev) => appendPendingUser(prev, text, pendingId));
       const expanded = await expandAtPathsInPrompt(text);
-      const result = await window.xAgent.turn.prompt(expanded);
+      const result = await window.xAgent.turn.prompt({ text: expanded });
       if (!result.ok || result.silent) {
         setItems((prev) => removePendingUser(prev, pendingId));
         if (!result.ok) {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -53,7 +53,7 @@ import {
   collapseFileBlocksToAtPaths,
   expandAtPathsInPrompt,
 } from "./lib/expandAtPaths";
-import { splitFilesForAttachment } from "./lib/file-attachment";
+import { splitFilesForAttachment, type FileReference } from "./lib/file-attachment";
 import { startersForProject } from "./lib/chat-starters";
 import { allGodotEditorToolsEnabled } from "./lib/ready-checklist";
 import {
@@ -113,6 +113,13 @@ export default function App() {
   const [error, setError] = useState<string | null>(null);
   const [input, setInput] = useState("");
   const [attachments, setAttachments] = useState<ImageContent[]>([]);
+  /**
+   * 拖入 / 粘贴的非图片文件. 不入 attachments (那是图片), 单独
+   * state. 短串显示在 input 文本 (📎 <basename>), 绝对路径
+   * 在 send 时拼到 user message (走 expandAtPaths 展开成 <file> 块)
+   * 让 AI 看到完整路径.
+   */
+  const [fileRefs, setFileRefs] = useState<FileReference[]>([]);
   const [busy, setBusy] = useState(false);
   const [sessionMode, setSessionMode] = useState<AgentSessionMode>("agent");
   const [sessionType, setSessionType] = useState<SessionType>(DEFAULT_SESSION_TYPE);
@@ -370,11 +377,14 @@ export default function App() {
       return;
     }
     const text = input.trim();
-    // Snapshot attachments before clearing input so we can pass them
-    // into the IPC payload. Cleared below to keep empty state on send.
+    // Snapshot attachments / fileRefs before clearing input so we can
+    // pass them into the IPC payload + expandAtPaths. Cleared below
+    // to keep empty state on send.
     const currentAttachments = attachments;
+    const currentFileRefs = fileRefs;
     setInput("");
     setAttachments([]);
+    setFileRefs([]);
     setError(null);
     setFollowNonce((n) => n + 1);
     dbgLog("chat", "send invoked", { len: text.length, preview: text.slice(0, 80), status, sessionMode });
@@ -442,7 +452,7 @@ export default function App() {
     setItems((prev) => appendPendingUser(prev, text, pendingId));
 
     const doneExpand = dbgTimer("chat", "expandAtPathsInPrompt");
-    const expanded = await expandAtPathsInPrompt(text);
+    const expanded = await expandAtPathsInPrompt(text, currentFileRefs);
     doneExpand();
     const doneRoundtrip = dbgTimer("chat", "window.xAgent.turn.prompt roundtrip");
     const result = await window.xAgent.turn.prompt({
@@ -456,7 +466,7 @@ export default function App() {
       if (!result.ok) setError(result.error ?? "发送失败");
     }
     await refreshSessions();
-  }, [input, attachments, cwd, sessionMode, goal, refreshSessions, status]);
+  }, [input, attachments, fileRefs, cwd, sessionMode, goal, refreshSessions, status]);
 
   /**
    * Composer 拖文件 / 粘贴文件时调用. 分类为图片 (入 attachments) 和
@@ -484,7 +494,14 @@ export default function App() {
       setAttachments((prev) => [...prev, ...images]);
     }
     if (references.length > 0) {
-      setInput((prev) => prev + references.join(""));
+      // Input 文本只显示短串 (📎 <basename>), 绝对路径单独存
+      // fileRefs state, send 时拼到 user message 末尾 (走
+      // expandAtPaths 展开成 <file> 块). 这样 composer 短, AI
+      // 拿到完整路径.
+      setInput((prev) =>
+        prev + references.map((r) => `📎 ${r.displayName} `).join(""),
+      );
+      setFileRefs((prev) => [...prev, ...references]);
     }
     if (notices.length > 0) {
       setError(notices.join("\n"));

--- a/apps/desktop/src/components/ChatPanel.tsx
+++ b/apps/desktop/src/components/ChatPanel.tsx
@@ -2,6 +2,7 @@ import type {
   AgentSessionMode,
   AgentStatus,
   GoalInfo,
+  ImageContent,
   ModelInfo,
   SessionSlashItem,
   ThinkingLevel,
@@ -39,6 +40,8 @@ import {
 import { useSlashMenu } from "../hooks/useSlashMenu";
 import { useAtCompletion, type AtPathCandidate } from "../hooks/useAtCompletion";
 import { ThinkingOrb } from "./ThinkingOrb";
+import { ComposerAttachments } from "./ComposerAttachments";
+import { MAX_IMAGE_COUNT } from "../lib/file-attachment";
 import type { RefObject } from "react";
 
 /** @-补全 path 候选暂未接入 file-tree IPC；空数组常量化避免每次渲染新建引用。 */
@@ -97,6 +100,14 @@ interface Props {
    * Used by parent to track scroll position (e.g. mount TopBar shadow).
    */
   externalStreamRef?: RefObject<HTMLDivElement | null>;
+  /** 已附图片 (粘贴截图 / 拖放图片). 非空时 composer 上方显示缩略图 chip. */
+  attachments?: ImageContent[];
+  /** Hard cap on attachment count, displayed in chip counter. */
+  maxAttachmentCount?: number;
+  /** 移除第 i 个附件 (附件状态由父组件维护). */
+  onRemoveAttachment?: (index: number) => void;
+  /** 拖文件 / 粘贴文件 → 分类后入 attachments + 拼 @<path> 引用到 input. */
+  onAddFiles?: (files: File[]) => void;
 }
 
 /** Render an "已等待 12s" suffix when the wait exceeds 3 seconds. */
@@ -118,6 +129,39 @@ function ChatPanelImpl(props: Props) {
   const composerLocked = props.disabled || Boolean(props.editingEntryId);
   const sessionMode = props.sessionMode ?? "agent";
   const modeSwitchDisabled = composerLocked || streaming;
+
+  // Drag-over visual for the composer shell. Files dropped anywhere
+  // on the shell are accepted (not just on the textarea).
+  const [isDragOver, setIsDragOver] = useState(false);
+  const attachments = props.attachments ?? [];
+  const maxAttachments = props.maxAttachmentCount ?? MAX_IMAGE_COUNT;
+  const onShellDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (!props.onAddFiles || composerLocked) return;
+      if (e.dataTransfer.types.includes("Files")) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "copy";
+        if (!isDragOver) setIsDragOver(true);
+      }
+    },
+    [props.onAddFiles, composerLocked, isDragOver],
+  );
+  const onShellDragLeave = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (e.currentTarget === e.target) setIsDragOver(false);
+    },
+    [],
+  );
+  const onShellDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      if (!props.onAddFiles || composerLocked) return;
+      e.preventDefault();
+      setIsDragOver(false);
+      const files = Array.from(e.dataTransfer.files);
+      if (files.length > 0) props.onAddFiles(files);
+    },
+    [props.onAddFiles, composerLocked],
+  );
 
   // 底部工具条：模型 / Thinking SelectMenu 的派生数据
   const modelOptions =
@@ -376,7 +420,16 @@ function ChatPanelImpl(props: Props) {
           className="composer-shell"
           data-session-mode={sessionMode}
           data-streaming={streaming ? "true" : undefined}
+          data-dragover={isDragOver ? "true" : undefined}
+          onDragOver={onShellDragOver}
+          onDragLeave={onShellDragLeave}
+          onDrop={onShellDrop}
         >
+          <ComposerAttachments
+            attachments={attachments}
+            onRemove={(i) => props.onRemoveAttachment?.(i)}
+            maxCount={maxAttachments}
+          />
           <SlashMenu
             open={menuOpen}
             items={filtered}
@@ -447,6 +500,22 @@ function ChatPanelImpl(props: Props) {
             onClick={syncCursor}
             onKeyUp={syncCursor}
             onSelect={syncCursor}
+            onPaste={(e) => {
+              if (!props.onAddFiles || composerLocked) return;
+              const items = e.clipboardData?.items;
+              if (!items) return;
+              for (const it of items) {
+                if (it.kind === "file" && it.type.startsWith("image/")) {
+                  const f = it.getAsFile();
+                  if (f) {
+                    e.preventDefault();
+                    props.onAddFiles([f]);
+                    return;
+                  }
+                }
+              }
+              // 非图片的 paste 走默认行为 (粘贴纯文本)
+            }}
             placeholder={
               props.disabled
                 ? "请先打开项目…"

--- a/apps/desktop/src/components/ChatPanel.tsx
+++ b/apps/desktop/src/components/ChatPanel.tsx
@@ -41,7 +41,7 @@ import { useSlashMenu } from "../hooks/useSlashMenu";
 import { useAtCompletion, type AtPathCandidate } from "../hooks/useAtCompletion";
 import { ThinkingOrb } from "./ThinkingOrb";
 import { ComposerAttachments } from "./ComposerAttachments";
-import { MAX_IMAGE_COUNT } from "../lib/file-attachment";
+import { MAX_IMAGE_COUNT, type FileReference } from "../lib/file-attachment";
 import type { RefObject } from "react";
 
 /** @-补全 path 候选暂未接入 file-tree IPC；空数组常量化避免每次渲染新建引用。 */
@@ -102,11 +102,15 @@ interface Props {
   externalStreamRef?: RefObject<HTMLDivElement | null>;
   /** 已附图片 (粘贴截图 / 拖放图片). 非空时 composer 上方显示缩略图 chip. */
   attachments?: ImageContent[];
+  /** 已附文件 (拖入 / 粘贴的非图片). 与图片共享同一片 chip 区域. */
+  fileRefs?: FileReference[];
   /** Hard cap on attachment count, displayed in chip counter. */
   maxAttachmentCount?: number;
-  /** 移除第 i 个附件 (附件状态由父组件维护). */
-  onRemoveAttachment?: (index: number) => void;
-  /** 拖文件 / 粘贴文件 → 分类后入 attachments + 拼 @<path> 引用到 input. */
+  /** 移除第 i 个图片附件. */
+  onRemoveImage?: (index: number) => void;
+  /** 移除第 i 个文件附件. */
+  onRemoveFile?: (index: number) => void;
+  /** 拖文件 / 粘贴文件 → 分类后入 attachments (图片) + fileRefs (其他). */
   onAddFiles?: (files: File[]) => void;
 }
 
@@ -134,6 +138,7 @@ function ChatPanelImpl(props: Props) {
   // on the shell are accepted (not just on the textarea).
   const [isDragOver, setIsDragOver] = useState(false);
   const attachments = props.attachments ?? [];
+  const fileRefs = props.fileRefs ?? [];
   const maxAttachments = props.maxAttachmentCount ?? MAX_IMAGE_COUNT;
   const onShellDragOver = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
@@ -427,8 +432,10 @@ function ChatPanelImpl(props: Props) {
         >
           <ComposerAttachments
             attachments={attachments}
-            onRemove={(i) => props.onRemoveAttachment?.(i)}
-            maxCount={maxAttachments}
+            fileRefs={fileRefs}
+            onRemoveImage={(i) => props.onRemoveImage?.(i)}
+            onRemoveFile={(i) => props.onRemoveFile?.(i)}
+            maxImageCount={maxAttachments}
           />
           <SlashMenu
             open={menuOpen}

--- a/apps/desktop/src/components/ComposerAttachments.test.tsx
+++ b/apps/desktop/src/components/ComposerAttachments.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Vitest 套件 —— ComposerAttachments 渲染 / 移除 / 4 张上限计数.
+ *
+ * 锁住 3 个不变量 (#42 composer attachments):
+ * 1. 空数组 → 返回 null (不渲染空容器)
+ * 2. 多个 attachment → 渲染对应数量的 chip + count "N/4"
+ * 3. 移除按钮回调时传正确的 index
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ComposerAttachments } from "./ComposerAttachments";
+import type { ImageContent } from "../../shared/ipc";
+
+function pngAttachment(): ImageContent {
+  return {
+    type: "image",
+    data: "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=",
+    mimeType: "image/png",
+  };
+}
+
+describe("ComposerAttachments 渲染", () => {
+  it("空数组 → 不渲染容器", () => {
+    const { container } = render(
+      <ComposerAttachments
+        attachments={[]}
+        onRemove={vi.fn()}
+        maxCount={4}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("1 个 attachment → 1 个 chip + 计数 1/4", () => {
+    render(
+      <ComposerAttachments
+        attachments={[pngAttachment()]}
+        onRemove={vi.fn()}
+        maxCount={4}
+      />,
+    );
+    expect(screen.getByRole("list")).toBeTruthy();
+    expect(screen.getByRole("listitem")).toBeTruthy();
+    expect(screen.getByText("1/4")).toBeTruthy();
+  });
+
+  it("3 个 attachment → 3 个 chip + 计数 3/4", () => {
+    const imgs = [pngAttachment(), pngAttachment(), pngAttachment()];
+    render(
+      <ComposerAttachments
+        attachments={imgs}
+        onRemove={vi.fn()}
+        maxCount={4}
+      />,
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(3);
+    expect(screen.getByText("3/4")).toBeTruthy();
+  });
+
+  it("maxCount 自定义 (比如 8 张实验性模式) → 计数显示 2/8", () => {
+    render(
+      <ComposerAttachments
+        attachments={[pngAttachment(), pngAttachment()]}
+        onRemove={vi.fn()}
+        maxCount={8}
+      />,
+    );
+    expect(screen.getByText("2/8")).toBeTruthy();
+  });
+});
+
+describe("ComposerAttachments 移除按钮", () => {
+  it("点 X 调 onRemove(index)", () => {
+    const onRemove = vi.fn();
+    render(
+      <ComposerAttachments
+        attachments={[pngAttachment(), pngAttachment()]}
+        onRemove={onRemove}
+        maxCount={4}
+      />,
+    );
+    const removeButtons = screen.getAllByRole("button", { name: "移除附件" });
+    expect(removeButtons).toHaveLength(2);
+    removeButtons[1]?.click();
+    expect(onRemove).toHaveBeenCalledWith(1);
+  });
+});

--- a/apps/desktop/src/components/ComposerAttachments.tsx
+++ b/apps/desktop/src/components/ComposerAttachments.tsx
@@ -1,0 +1,48 @@
+/**
+ * ComposerAttachments —— 缩略图 + chip 列表, 显示在 textarea 上方.
+ *
+ * 用户从剪贴板 / 拖放拿到图片后, 这里渲染缩略图 + 移除按钮.
+ * 非图片走 @<path> 引用注入到 textarea 文本, 不显示在这里.
+ */
+import { X } from "lucide-react";
+import type { ImageContent } from "../../shared/ipc";
+
+export function ComposerAttachments({
+  attachments,
+  onRemove,
+  maxCount,
+}: {
+  attachments: ImageContent[];
+  onRemove: (index: number) => void;
+  maxCount: number;
+}) {
+  if (attachments.length === 0) return null;
+  return (
+    <div className="composer-attachments" role="list" aria-label="已附图片">
+      {attachments.map((a, i) => (
+        <div
+          key={`${a.mimeType}:${i}`}
+          className="composer-attachment-chip"
+          role="listitem"
+        >
+          <img
+            src={`data:${a.mimeType};base64,${a.data}`}
+            alt=""
+            className="composer-attachment-thumb"
+          />
+          <button
+            type="button"
+            aria-label="移除附件"
+            className="composer-attachment-remove"
+            onClick={() => onRemove(i)}
+          >
+            <X size={12} aria-hidden />
+          </button>
+        </div>
+      ))}
+      <span className="composer-attachments-count" aria-live="polite">
+        {attachments.length}/{maxCount}
+      </span>
+    </div>
+  );
+}

--- a/apps/desktop/src/components/ComposerAttachments.tsx
+++ b/apps/desktop/src/components/ComposerAttachments.tsx
@@ -1,27 +1,39 @@
 /**
- * ComposerAttachments —— 缩略图 + chip 列表, 显示在 textarea 上方.
+ * ComposerAttachments —— composer 内部的附件 chip 列表, 显示在 textarea 上方.
  *
- * 用户从剪贴板 / 拖放拿到图片后, 这里渲染缩略图 + 移除按钮.
- * 非图片走 @<path> 引用注入到 textarea 文本, 不显示在这里.
+ * 两种附件共用同一个区域:
+ * - 图片: 缩略图 (base64 data URL) + 移除按钮
+ * - 文件: 文件图标 + basename + 移除按钮
+ *
+ * 两种附件都通过 App.tsx 的 state 管理, 这里只负责渲染.
  */
-import { X } from "lucide-react";
+import { FileText, X } from "lucide-react";
 import type { ImageContent } from "../../shared/ipc";
+import type { FileReference } from "../lib/file-attachment";
 
 export function ComposerAttachments({
   attachments,
-  onRemove,
-  maxCount,
+  fileRefs,
+  onRemoveImage,
+  onRemoveFile,
+  maxImageCount,
 }: {
   attachments: ImageContent[];
-  onRemove: (index: number) => void;
-  maxCount: number;
+  fileRefs: FileReference[];
+  onRemoveImage: (index: number) => void;
+  onRemoveFile: (index: number) => void;
+  maxImageCount: number;
 }) {
-  if (attachments.length === 0) return null;
+  if (attachments.length === 0 && fileRefs.length === 0) return null;
   return (
-    <div className="composer-attachments" role="list" aria-label="已附图片">
+    <div
+      className="composer-attachments"
+      role="list"
+      aria-label="已附图片与文件"
+    >
       {attachments.map((a, i) => (
         <div
-          key={`${a.mimeType}:${i}`}
+          key={`image:${a.mimeType}:${i}`}
           className="composer-attachment-chip"
           role="listitem"
         >
@@ -32,17 +44,43 @@ export function ComposerAttachments({
           />
           <button
             type="button"
-            aria-label="移除附件"
+            aria-label="移除图片附件"
             className="composer-attachment-remove"
-            onClick={() => onRemove(i)}
+            onClick={() => onRemoveImage(i)}
           >
             <X size={12} aria-hidden />
           </button>
         </div>
       ))}
-      <span className="composer-attachments-count" aria-live="polite">
-        {attachments.length}/{maxCount}
-      </span>
+      {fileRefs.map((f, i) => (
+        <div
+          key={`file:${f.absPath}:${i}`}
+          className="composer-attachment-chip composer-attachment-chip-file"
+          role="listitem"
+          title={f.absPath}
+        >
+          <FileText
+            size={20}
+            aria-hidden
+            className="composer-attachment-file-icon"
+          />
+          <span className="composer-attachment-file-name">{f.displayName}</span>
+          <button
+            type="button"
+            aria-label={`移除文件附件：${f.displayName}`}
+            className="composer-attachment-remove"
+            onClick={() => onRemoveFile(i)}
+          >
+            <X size={12} aria-hidden />
+          </button>
+        </div>
+      ))}
+      {(attachments.length > 0 || fileRefs.length > 0) && (
+        <span className="composer-attachments-count" aria-live="polite">
+          {attachments.length}/{maxImageCount}
+          {fileRefs.length > 0 && ` · ${fileRefs.length} 文件`}
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/UserMessageBody.tsx
+++ b/apps/desktop/src/components/UserMessageBody.tsx
@@ -16,8 +16,14 @@ import {
 
 function FileRefChip({ name, content }: { name: string; content: string }) {
   const [open, setOpen] = useState(false);
-  const label = name.trim() || "file";
-  const lines = content ? content.split(/\r?\n/).length : 0;
+  const fullPath = name.trim() || "file";
+  // Short display: show only the basename so chat history doesn't
+  // drown in absolute paths (e.g. D:/UGit/z-2/config/01_chess.csv
+  // → "01_chess.csv"). Full path lives in title attribute for hover
+  // + accessibility.
+  const shortName = basename(fullPath) || fullPath;
+  const isEmpty = content.trim().length === 0;
+  const lines = isEmpty ? 0 : content.split(/\r?\n/).length;
 
   return (
     <details
@@ -25,17 +31,37 @@ function FileRefChip({ name, content }: { name: string; content: string }) {
       open={open}
       onToggle={(e) => setOpen(e.currentTarget.open)}
     >
-      <summary className="user-file-ref-summary" title={label}>
+      <summary
+        className="user-file-ref-summary"
+        title={fullPath}
+        aria-label={fullPath}
+      >
         <ChevronRight size={12} className="user-file-ref-chevron" aria-hidden />
         <FileText size={12} aria-hidden />
-        <span className="user-file-ref-at">@{label}</span>
-        {lines > 0 && (
+        <span className="user-file-ref-at">{shortName}</span>
+        {isEmpty && (
+          <span className="user-file-ref-meta">未展开</span>
+        )}
+        {!isEmpty && lines > 0 && (
           <span className="user-file-ref-meta">{lines} 行</span>
         )}
       </summary>
-      <pre className="user-file-ref-body">{content}</pre>
+      {isEmpty ? (
+        <pre className="user-file-ref-body user-file-ref-body-empty">
+          （文件未在 prompt 中展开；完整路径：{fullPath}）
+        </pre>
+      ) : (
+        <pre className="user-file-ref-body">{content}</pre>
+      )}
     </details>
   );
+}
+
+/** Cross-platform basename (renderer has no `path` module). */
+function basename(p: string): string {
+  if (!p) return "";
+  const m = /([^/\\]+)[/\\]*$/.exec(p);
+  return m ? m[1]! : p;
 }
 
 function ModeRefChip({ name, content }: { name: string; content: string }) {

--- a/apps/desktop/src/lib/expandAtPaths.ts
+++ b/apps/desktop/src/lib/expandAtPaths.ts
@@ -61,9 +61,29 @@ export function collapseFileBlocksToAtPaths(text: string): string {
   return out.replace(/\n{3,}/g, "\n\n").trimEnd();
 }
 
-export async function expandAtPathsInPrompt(text: string): Promise<string> {
+export async function expandAtPathsInPrompt(
+  text: string,
+  extraRefs: ReadonlyArray<{ absPath: string; displayName?: string }> = [],
+): Promise<string> {
+  // Pass 1: extra refs from drag/drop (e.g. "📎 foo.csv" markers).
+  // Force-resolve from absolute path; emit empty `<file>` block on
+  // failure so the renderer still collapses it to a chip.
+  const extraBlocks: string[] = [];
+  for (const r of extraRefs) {
+    const abs = r.absPath;
+    if (!abs) continue;
+    const res = await window.xAgent.readProjectFile(abs);
+    if (res.ok && res.content != null) {
+      extraBlocks.push(`<file name="${abs}">\n${res.content}\n</file>`);
+    } else {
+      // cwd 外 / 二进制 / 过大 → 保留绝对路径作为 file 块, content 空
+      extraBlocks.push(`<file name="${abs}">\n</file>`);
+    }
+  }
+
+  // Pass 2: `@<rel-or-abs>` tokens inside the composer text.
   const matches = [...text.matchAll(AT_PATH_RE)];
-  if (matches.length === 0) return text;
+  if (matches.length === 0 && extraBlocks.length === 0) return text;
 
   const unique = [
     ...new Set(matches.map((m) => m[1].replace(/\\/g, "/"))),
@@ -85,8 +105,13 @@ export async function expandAtPathsInPrompt(text: string): Promise<string> {
     }),
   );
 
-  return text.replace(AT_PATH_RE, (full, rawPath: string) => {
+  const replaced = text.replace(AT_PATH_RE, (full, rawPath: string) => {
     const rel = rawPath.replace(/\\/g, "/");
     return expansions.get(rel) ?? full;
   });
+
+  if (extraBlocks.length === 0) return replaced;
+  // Append extra refs as a trailing block. Empty line keeps the
+  // user's prose separate from the file references.
+  return `${replaced}${replaced.endsWith("\n") ? "" : "\n\n"}${extraBlocks.join("\n")}`;
 }

--- a/apps/desktop/src/lib/file-attachment.test.ts
+++ b/apps/desktop/src/lib/file-attachment.test.ts
@@ -1,13 +1,15 @@
 /**
  * Vitest 套件 —— file → attachment helpers (renderer-side).
  *
- * 锁住 4 个不变量 (#42 composer attachments):
+ * 锁住 5 个不变量 (#42 composer attachments + #44 绝对路径):
  * 1. SUPPORTED_IMAGE_MIME 白名单 (png/jpeg/gif/webp 之外 → 非图片)
  * 2. MAX_IMAGE_BYTES 单张上限 (4MB)
  * 3. MAX_IMAGE_COUNT 总数上限 (4 张)
- * 4. 非图片走 @<path> 引用, 不读内容塞 prompt
+ * 4. 非图片走 <file name="<abs path>"> 块 (空 content, name 用绝对路径)
+ * 5. 切到绝对路径: splitFilesForAttachment 接 FileInput[] (含 absPath),
+ *    不再读 f.path (Electron 32+ 不可用)
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import {
   SUPPORTED_IMAGE_MIME,
   MAX_IMAGE_BYTES,
@@ -15,13 +17,20 @@ import {
   isSupportedImage,
   readFileAsImageContent,
   splitFilesForAttachment,
+  type FileInput,
 } from "./file-attachment";
 
-function makeFile(name: string, type: string, sizeBytes: number, path = ""): File {
-  // jsdom File doesn't have `path`; cast through unknown to inject.
-  const f = new File([new Uint8Array(sizeBytes)], name, { type });
-  if (path) (f as unknown as { path: string }).path = path;
-  return f;
+function makeFile(name: string, type: string, sizeBytes: number): File {
+  return new File([new Uint8Array(sizeBytes)], name, { type });
+}
+
+/** Wrap File + absPath + optional fallback into a FileInput. */
+function input(
+  file: File,
+  absPath: string,
+  fallbackName?: string,
+): FileInput {
+  return { file, absPath, fallbackName };
 }
 
 describe("SUPPORTED_IMAGE_MIME 白名单", () => {
@@ -61,11 +70,9 @@ describe("readFileAsImageContent", () => {
   });
 
   it("正常 PNG 转 base64, 不带 data: 前缀", async () => {
-    // Stub FileReader to deterministic output
     const original = globalThis.FileReader;
     class StubFR {
       result: string | null = null;
-      error: unknown = null;
       onload: ((ev: unknown) => void) | null = null;
       onerror: ((ev: unknown) => void) | null = null;
       readAsDataURL(_file: File): void {
@@ -88,32 +95,59 @@ describe("readFileAsImageContent", () => {
 });
 
 describe("splitFilesForAttachment", () => {
-  it("非图片 → references, 不入 images", async () => {
-    const f = makeFile("data.csv", "text/csv", 10, "D:/x/data.csv");
-    const out = await splitFilesForAttachment([f]);
+  it("非图片 → <file name=\"<abs path>\"> 块 (空 content)", async () => {
+    const f = makeFile("data.csv", "text/csv", 10);
+    const out = await splitFilesForAttachment([
+      input(f, "D:/x/data.csv"),
+    ]);
     expect(out.images).toEqual([]);
-    expect(out.references).toEqual(["@D:/x/data.csv "]);
+    expect(out.references).toEqual([
+      '<file name="D:/x/data.csv">\n</file>',
+    ]);
   });
 
-  it("多文件混合: 图片入 images, 非图片入 references", async () => {
-    // stub FileReader for image
+  it("绝对路径优先: 不再用 f.name (Electron 32+ 不可用)", async () => {
+    const f = makeFile("data.csv", "text/csv", 10);
+    const out = await splitFilesForAttachment([
+      input(f, "D:/abs/path/data.csv"),
+    ]);
+    // name attribute 必须是绝对路径, 不是 f.name ("data.csv")
+    expect(out.references[0]).toContain('name="D:/abs/path/data.csv"');
+  });
+
+  it("Windows 反斜杠路径在 attr 内 → 转正斜杠 (与 @<path> 风格一致)", async () => {
+    const f = makeFile("data.csv", "text/csv", 10);
+    const out = await splitFilesForAttachment([
+      input(f, "D:\\UGit\\x\\data.csv"),
+    ]);
+    // 我们的 escapeAttr 不转 slash, 但 basename 兼容两种.
+    // 主要确认 name 含原 Windows 路径.
+    expect(out.references[0]).toContain("D:");
+  });
+
+  it("多文件混合: 图片入 images, 非图片入 <file> 块", async () => {
     const original = globalThis.FileReader;
     class StubFR {
-      result: string | null = null;
       onload: ((ev: unknown) => void) | null = null;
       onerror: ((ev: unknown) => void) | null = null;
       readAsDataURL(_file: File): void {
-        this.result = "data:image/png;base64,QUJD";
-        queueMicrotask(() => this.onload?.(null));
+        queueMicrotask(() =>
+          this.onload?.({ target: { result: "data:image/png;base64,QUJD" } } as unknown),
+        );
       }
     }
     globalThis.FileReader = StubFR as unknown as typeof FileReader;
     try {
       const png = makeFile("a.png", "image/png", 100);
-      const csv = makeFile("b.csv", "text/csv", 50, "D:/b.csv");
-      const out = await splitFilesForAttachment([png, csv]);
+      const csv = makeFile("b.csv", "text/csv", 50);
+      const out = await splitFilesForAttachment([
+        input(png, "D:/a.png"),
+        input(csv, "D:/b.csv"),
+      ]);
       expect(out.images).toHaveLength(1);
-      expect(out.references).toEqual(["@D:/b.csv "]);
+      expect(out.references).toEqual([
+        '<file name="D:/b.csv">\n</file>',
+      ]);
     } finally {
       globalThis.FileReader = original;
     }
@@ -132,10 +166,10 @@ describe("splitFilesForAttachment", () => {
     }
     globalThis.FileReader = StubFR as unknown as typeof FileReader;
     try {
-      const files = Array.from({ length: 6 }, (_, i) =>
-        makeFile(`f${i}.png`, "image/png", 100),
+      const items = Array.from({ length: 6 }, (_, i) =>
+        input(makeFile(`f${i}.png`, "image/png", 100), `D:/f${i}.png`),
       );
-      const out = await splitFilesForAttachment(files);
+      const out = await splitFilesForAttachment(items);
       expect(out.images).toHaveLength(MAX_IMAGE_COUNT);
       expect(out.notices.some((n) => n.includes("上限"))).toBe(true);
     } finally {
@@ -143,17 +177,44 @@ describe("splitFilesForAttachment", () => {
     }
   });
 
-  it("非图片无 path 字段 → 用 f.name 兜底, 不报错", async () => {
+  it("absPath 空 → 用 fallbackName (或 f.name), 不报错", async () => {
     const f = makeFile("only-name.txt", "text/plain", 5);
-    const out = await splitFilesForAttachment([f]);
-    // jsdom File 没有 path, splitFilesForAttachment 退到 f.name 作 fallback
-    expect(out.references).toEqual(["@only-name.txt "]);
+    const out = await splitFilesForAttachment([
+      input(f, "", "fallback.txt"),
+    ]);
+    expect(out.references).toEqual([
+      '<file name="fallback.txt">\n</file>',
+    ]);
+  });
+
+  it("absPath + fallbackName 都空 → 退到 f.name 兜底 (浏览器 File.name 总有值)", async () => {
+    const f = makeFile("orphan.txt", "text/plain", 5);
+    const out = await splitFilesForAttachment([input(f, "")]);
+    // 三层 fallback: absPath → fallbackName → f.name
+    expect(out.references).toEqual([
+      '<file name="orphan.txt">\n</file>',
+    ]);
   });
 
   it("超大图片单张 → 进 notices, 不入 images", async () => {
     const big = makeFile("big.png", "image/png", MAX_IMAGE_BYTES + 1);
-    const out = await splitFilesForAttachment([big]);
+    const out = await splitFilesForAttachment([
+      input(big, "D:/big.png"),
+    ]);
     expect(out.images).toEqual([]);
     expect(out.notices.some((n) => n.includes("图片过大"))).toBe(true);
+    // notice 用 basename 而不是全路径
+    expect(out.notices[0]).toContain("big.png");
+    expect(out.notices[0]).not.toContain("D:/big.png");
+  });
+
+  it("XML 注入防御: 路径含 '\"' 或 '<' 时 attr 被转义", async () => {
+    const f = makeFile("a.csv", "text/csv", 10);
+    const out = await splitFilesForAttachment([
+      input(f, 'D:/x/"<script>.csv'),
+    ]);
+    expect(out.references[0]).toContain("&quot;");
+    expect(out.references[0]).toContain("&lt;");
+    expect(out.references[0]).not.toContain('"<script>');
   });
 });

--- a/apps/desktop/src/lib/file-attachment.test.ts
+++ b/apps/desktop/src/lib/file-attachment.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Vitest 套件 —— file → attachment helpers (renderer-side).
+ *
+ * 锁住 4 个不变量 (#42 composer attachments):
+ * 1. SUPPORTED_IMAGE_MIME 白名单 (png/jpeg/gif/webp 之外 → 非图片)
+ * 2. MAX_IMAGE_BYTES 单张上限 (4MB)
+ * 3. MAX_IMAGE_COUNT 总数上限 (4 张)
+ * 4. 非图片走 @<path> 引用, 不读内容塞 prompt
+ */
+import { describe, it, expect, vi } from "vitest";
+import {
+  SUPPORTED_IMAGE_MIME,
+  MAX_IMAGE_BYTES,
+  MAX_IMAGE_COUNT,
+  isSupportedImage,
+  readFileAsImageContent,
+  splitFilesForAttachment,
+} from "./file-attachment";
+
+function makeFile(name: string, type: string, sizeBytes: number, path = ""): File {
+  // jsdom File doesn't have `path`; cast through unknown to inject.
+  const f = new File([new Uint8Array(sizeBytes)], name, { type });
+  if (path) (f as unknown as { path: string }).path = path;
+  return f;
+}
+
+describe("SUPPORTED_IMAGE_MIME 白名单", () => {
+  it("接受 png/jpeg/gif/webp", () => {
+    expect(SUPPORTED_IMAGE_MIME.has("image/png")).toBe(true);
+    expect(SUPPORTED_IMAGE_MIME.has("image/jpeg")).toBe(true);
+    expect(SUPPORTED_IMAGE_MIME.has("image/gif")).toBe(true);
+    expect(SUPPORTED_IMAGE_MIME.has("image/webp")).toBe(true);
+  });
+
+  it("拒绝其他 mime (svg, bmp, heic, octet-stream)", () => {
+    expect(SUPPORTED_IMAGE_MIME.has("image/svg+xml")).toBe(false);
+    expect(SUPPORTED_IMAGE_MIME.has("image/bmp")).toBe(false);
+    expect(SUPPORTED_IMAGE_MIME.has("image/heic")).toBe(false);
+    expect(SUPPORTED_IMAGE_MIME.has("application/octet-stream")).toBe(false);
+  });
+});
+
+describe("isSupportedImage", () => {
+  it("true for image/png", () => {
+    expect(isSupportedImage(makeFile("a.png", "image/png", 100))).toBe(true);
+  });
+  it("false for text/csv", () => {
+    expect(isSupportedImage(makeFile("a.csv", "text/csv", 100))).toBe(false);
+  });
+});
+
+describe("readFileAsImageContent", () => {
+  it("非支持 mime 返回 null", async () => {
+    const f = makeFile("a.svg", "image/svg+xml", 100);
+    expect(await readFileAsImageContent(f)).toBeNull();
+  });
+
+  it("超大 (>4MB) 返回 null", async () => {
+    const f = makeFile("big.png", "image/png", MAX_IMAGE_BYTES + 1);
+    expect(await readFileAsImageContent(f)).toBeNull();
+  });
+
+  it("正常 PNG 转 base64, 不带 data: 前缀", async () => {
+    // Stub FileReader to deterministic output
+    const original = globalThis.FileReader;
+    class StubFR {
+      result: string | null = null;
+      error: unknown = null;
+      onload: ((ev: unknown) => void) | null = null;
+      onerror: ((ev: unknown) => void) | null = null;
+      readAsDataURL(_file: File): void {
+        this.result = "data:image/png;base64,QUJD";
+        queueMicrotask(() => this.onload?.(null));
+      }
+    }
+    globalThis.FileReader = StubFR as unknown as typeof FileReader;
+    try {
+      const f = makeFile("ok.png", "image/png", 100);
+      const out = await readFileAsImageContent(f);
+      expect(out).not.toBeNull();
+      expect(out!.type).toBe("image");
+      expect(out!.data).toBe("QUJD");
+      expect(out!.mimeType).toBe("image/png");
+    } finally {
+      globalThis.FileReader = original;
+    }
+  });
+});
+
+describe("splitFilesForAttachment", () => {
+  it("非图片 → references, 不入 images", async () => {
+    const f = makeFile("data.csv", "text/csv", 10, "D:/x/data.csv");
+    const out = await splitFilesForAttachment([f]);
+    expect(out.images).toEqual([]);
+    expect(out.references).toEqual(["@D:/x/data.csv "]);
+  });
+
+  it("多文件混合: 图片入 images, 非图片入 references", async () => {
+    // stub FileReader for image
+    const original = globalThis.FileReader;
+    class StubFR {
+      result: string | null = null;
+      onload: ((ev: unknown) => void) | null = null;
+      onerror: ((ev: unknown) => void) | null = null;
+      readAsDataURL(_file: File): void {
+        this.result = "data:image/png;base64,QUJD";
+        queueMicrotask(() => this.onload?.(null));
+      }
+    }
+    globalThis.FileReader = StubFR as unknown as typeof FileReader;
+    try {
+      const png = makeFile("a.png", "image/png", 100);
+      const csv = makeFile("b.csv", "text/csv", 50, "D:/b.csv");
+      const out = await splitFilesForAttachment([png, csv]);
+      expect(out.images).toHaveLength(1);
+      expect(out.references).toEqual(["@D:/b.csv "]);
+    } finally {
+      globalThis.FileReader = original;
+    }
+  });
+
+  it("超 4 张图: 第 5 张 + 之后走 notice", async () => {
+    const original = globalThis.FileReader;
+    class StubFR {
+      onload: ((ev: unknown) => void) | null = null;
+      onerror: ((ev: unknown) => void) | null = null;
+      readAsDataURL(_file: File): void {
+        queueMicrotask(() =>
+          this.onload?.({ target: { result: "data:image/png;base64,X" } } as unknown),
+        );
+      }
+    }
+    globalThis.FileReader = StubFR as unknown as typeof FileReader;
+    try {
+      const files = Array.from({ length: 6 }, (_, i) =>
+        makeFile(`f${i}.png`, "image/png", 100),
+      );
+      const out = await splitFilesForAttachment(files);
+      expect(out.images).toHaveLength(MAX_IMAGE_COUNT);
+      expect(out.notices.some((n) => n.includes("上限"))).toBe(true);
+    } finally {
+      globalThis.FileReader = original;
+    }
+  });
+
+  it("非图片无 path 字段 → 用 f.name 兜底, 不报错", async () => {
+    const f = makeFile("only-name.txt", "text/plain", 5);
+    const out = await splitFilesForAttachment([f]);
+    // jsdom File 没有 path, splitFilesForAttachment 退到 f.name 作 fallback
+    expect(out.references).toEqual(["@only-name.txt "]);
+  });
+
+  it("超大图片单张 → 进 notices, 不入 images", async () => {
+    const big = makeFile("big.png", "image/png", MAX_IMAGE_BYTES + 1);
+    const out = await splitFilesForAttachment([big]);
+    expect(out.images).toEqual([]);
+    expect(out.notices.some((n) => n.includes("图片过大"))).toBe(true);
+  });
+});

--- a/apps/desktop/src/lib/file-attachment.test.ts
+++ b/apps/desktop/src/lib/file-attachment.test.ts
@@ -95,14 +95,14 @@ describe("readFileAsImageContent", () => {
 });
 
 describe("splitFilesForAttachment", () => {
-  it("非图片 → <file name=\"<abs path>\"> 块 (空 content)", async () => {
+  it("非图片 → references: {absPath, displayName}, basename 来自 absPath", async () => {
     const f = makeFile("data.csv", "text/csv", 10);
     const out = await splitFilesForAttachment([
       input(f, "D:/x/data.csv"),
     ]);
     expect(out.images).toEqual([]);
     expect(out.references).toEqual([
-      '<file name="D:/x/data.csv">\n</file>',
+      { absPath: "D:/x/data.csv", displayName: "data.csv" },
     ]);
   });
 
@@ -111,21 +111,27 @@ describe("splitFilesForAttachment", () => {
     const out = await splitFilesForAttachment([
       input(f, "D:/abs/path/data.csv"),
     ]);
-    // name attribute 必须是绝对路径, 不是 f.name ("data.csv")
-    expect(out.references[0]).toContain('name="D:/abs/path/data.csv"');
+    // absPath 必须是绝对路径, 不是 f.name ("data.csv")
+    expect(out.references[0]?.absPath).toBe("D:/abs/path/data.csv");
   });
 
-  it("Windows 反斜杠路径在 attr 内 → 转正斜杠 (与 @<path> 风格一致)", async () => {
+  it("Windows 反斜杠路径: basename 兼容 (取最后一段, 不论 / 还是 \\)", async () => {
     const f = makeFile("data.csv", "text/csv", 10);
     const out = await splitFilesForAttachment([
       input(f, "D:\\UGit\\x\\data.csv"),
     ]);
-    // 我们的 escapeAttr 不转 slash, 但 basename 兼容两种.
-    // 主要确认 name 含原 Windows 路径.
-    expect(out.references[0]).toContain("D:");
+    expect(out.references[0]?.displayName).toBe("data.csv");
   });
 
-  it("多文件混合: 图片入 images, 非图片入 <file> 块", async () => {
+  it("displayName 路径里有子目录: basename 取最后一段", async () => {
+    const f = makeFile("ignored", "text/csv", 10);
+    const out = await splitFilesForAttachment([
+      input(f, "D:/UGit/z-2/config/01_chess_pieces.csv"),
+    ]);
+    expect(out.references[0]?.displayName).toBe("01_chess_pieces.csv");
+  });
+
+  it("多文件混合: 图片入 images, 非图片入 references", async () => {
     const original = globalThis.FileReader;
     class StubFR {
       onload: ((ev: unknown) => void) | null = null;
@@ -146,7 +152,7 @@ describe("splitFilesForAttachment", () => {
       ]);
       expect(out.images).toHaveLength(1);
       expect(out.references).toEqual([
-        '<file name="D:/b.csv">\n</file>',
+        { absPath: "D:/b.csv", displayName: "b.csv" },
       ]);
     } finally {
       globalThis.FileReader = original;
@@ -177,22 +183,21 @@ describe("splitFilesForAttachment", () => {
     }
   });
 
-  it("absPath 空 → 用 fallbackName (或 f.name), 不报错", async () => {
+  it("absPath 空 → 用 fallbackName 作 absPath (displayName 也取 fallbackName)", async () => {
     const f = makeFile("only-name.txt", "text/plain", 5);
     const out = await splitFilesForAttachment([
       input(f, "", "fallback.txt"),
     ]);
     expect(out.references).toEqual([
-      '<file name="fallback.txt">\n</file>',
+      { absPath: "fallback.txt", displayName: "fallback.txt" },
     ]);
   });
 
-  it("absPath + fallbackName 都空 → 退到 f.name 兜底 (浏览器 File.name 总有值)", async () => {
+  it("absPath + fallbackName 都空 → 退到 f.name 兜底", async () => {
     const f = makeFile("orphan.txt", "text/plain", 5);
     const out = await splitFilesForAttachment([input(f, "")]);
-    // 三层 fallback: absPath → fallbackName → f.name
     expect(out.references).toEqual([
-      '<file name="orphan.txt">\n</file>',
+      { absPath: "orphan.txt", displayName: "orphan.txt" },
     ]);
   });
 
@@ -206,15 +211,5 @@ describe("splitFilesForAttachment", () => {
     // notice 用 basename 而不是全路径
     expect(out.notices[0]).toContain("big.png");
     expect(out.notices[0]).not.toContain("D:/big.png");
-  });
-
-  it("XML 注入防御: 路径含 '\"' 或 '<' 时 attr 被转义", async () => {
-    const f = makeFile("a.csv", "text/csv", 10);
-    const out = await splitFilesForAttachment([
-      input(f, 'D:/x/"<script>.csv'),
-    ]);
-    expect(out.references[0]).toContain("&quot;");
-    expect(out.references[0]).toContain("&lt;");
-    expect(out.references[0]).not.toContain('"<script>');
   });
 });

--- a/apps/desktop/src/lib/file-attachment.ts
+++ b/apps/desktop/src/lib/file-attachment.ts
@@ -44,18 +44,30 @@ export interface FileInput {
   fallbackName?: string;
 }
 
+/**
+ * A dropped/pasted non-image file. Carries the basename for short
+ * display in the composer, plus the absolute path the model needs
+ * to `read` it. Composer shows `📎 <basename>`; the absolute path
+ * flows out-of-band to the send pipeline so the model sees it.
+ */
+export interface FileReference {
+  /** Absolute path on disk (empty if Electron could not resolve). */
+  absPath: string;
+  /** Basename (e.g. "01_chess_pieces.csv"). */
+  displayName: string;
+}
+
 /** Result of splitting dropped / pasted files into image vs reference. */
 export interface AttachmentSplit {
   /** Image attachments ready to be added to `ImageContent[]`. */
   images: ImageContent[];
   /**
-   * `<file name="<abs path>">\n</file>` blocks (empty content). Pushed
-   * into the composer input verbatim. User message renderer collapses
-   * these to a chip with basename + tooltip = full path. The absolute
-   * path is preserved in the `name` attribute so the model can use
-   * the `read` tool with the full path.
+   * File references. Caller decides how to surface them in the
+   * composer (short chip, `<file>` block, etc.) and how to ship the
+   * absolute path to the model (PromptPayload extensions, separate
+   * send pipeline, etc.).
    */
-  references: string[];
+  references: FileReference[];
   /** Notes for the user (skipped files with reasons). */
   notices: string[];
 }
@@ -95,7 +107,7 @@ export async function splitFilesForAttachment(
   items: FileInput[],
 ): Promise<AttachmentSplit> {
   const images: ImageContent[] = [];
-  const references: string[] = [];
+  const references: FileReference[] = [];
   const notices: string[] = [];
   let imageSkipped = 0;
   for (const { file, absPath, fallbackName } of items) {
@@ -123,17 +135,20 @@ export async function splitFilesForAttachment(
       }
       continue;
     }
-    // Non-image: emit `<file name="<abs path>">\n</file>` block. The
-    // block name carries the absolute path so the model can `read` it.
-    // expandAtPaths does not touch pre-existing `<file>` blocks, so
-    // this round-trips verbatim. The renderer collapses it to a chip
-    // showing the basename (full path in tooltip).
-    const ref = absPath || fallbackName || file.name;
-    if (!ref) {
+    // Non-image: emit structured FileReference. Caller renders
+    // `📎 <displayName>` in composer (short) and ships `<absPath>` to
+    // the model out-of-band (e.g. via `<file>` block appended to
+    // expanded prompt). Keeps the composer free of long paths while
+    // preserving the model-side reference.
+    const refPath = absPath || fallbackName || file.name;
+    if (!refPath) {
       notices.push(`文件无路径，已跳过：${file.name}`);
       continue;
     }
-    references.push(`<file name="${escapeAttr(ref)}">\n</file>`);
+    references.push({
+      absPath: refPath,
+      displayName,
+    });
   }
   if (imageSkipped > 0) {
     notices.push(`已达图片上限 ${MAX_IMAGE_COUNT} 张，跳过 ${imageSkipped} 张`);
@@ -147,15 +162,6 @@ function basename(p: string): string {
   // Strip both Unix and Windows separators, take last segment.
   const m = /([^/\\]+)[/\\]*$/.exec(p);
   return m ? m[1]! : p;
-}
-
-/** Escape `<` / `>` / `"` / `&` for safe insertion into XML-ish attributes. */
-function escapeAttr(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
 }
 
 function readAsDataUrl(file: File): Promise<string> {

--- a/apps/desktop/src/lib/file-attachment.ts
+++ b/apps/desktop/src/lib/file-attachment.ts
@@ -1,0 +1,129 @@
+/**
+ * File → attachment helpers for the composer.
+ *
+ * Three public entry points:
+ * - `readFileAsImageContent(file)` —— read a single File, return
+ *   ImageContent or null if the file isn't a supported image.
+ * - `splitFilesForAttachment(files)` —— classify into images
+ *   (returned) and non-image paths (returned for `@<path>` 注入
+ *   input text by the caller).
+ * - `MAX_IMAGE_BYTES` / `MAX_IMAGE_COUNT` —— caller-side gates
+ *   that match this module's enforcement.
+ *
+ * The renderer is the only consumer; the file payload is sent
+ * over IPC as part of `PromptPayload.images`.
+ */
+import type { ImageContent } from "../../shared/ipc";
+
+/** Whitelisted mime types. Anything else is treated as non-image. */
+export const SUPPORTED_IMAGE_MIME = new Set<string>([
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+]);
+
+/** Single-image size cap (raw bytes). 4 MB ≈ 3 MB base64 with overhead. */
+export const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
+
+/** Hard cap on the number of images per prompt. */
+export const MAX_IMAGE_COUNT = 4;
+
+/** Result of splitting dropped / pasted files into image vs reference. */
+export interface AttachmentSplit {
+  /** Image attachments ready to be added to `ImageContent[]`. */
+  images: ImageContent[];
+  /** Paths / references that should be appended to the input text as `@<path>`. */
+  references: string[];
+  /** Notes for the user (skipped files with reasons). */
+  notices: string[];
+}
+
+/** True if the browser File object represents a supported image type. */
+export function isSupportedImage(file: File): boolean {
+  return SUPPORTED_IMAGE_MIME.has(file.type);
+}
+
+/**
+ * Read a single File as base64 (no `data:` URL prefix) and return an
+ * ImageContent. Returns null if the file isn't a supported image or
+ * exceeds the size cap.
+ */
+export async function readFileAsImageContent(
+  file: File,
+): Promise<ImageContent | null> {
+  if (!isSupportedImage(file)) return null;
+  if (file.size > MAX_IMAGE_BYTES) return null;
+  const dataUrl = await readAsDataUrl(file);
+  // dataUrl looks like "data:image/png;base64,XXXX" — keep only the body.
+  const comma = dataUrl.indexOf(",");
+  const base64 = comma >= 0 ? dataUrl.slice(comma + 1) : dataUrl;
+  return { type: "image", data: base64, mimeType: file.type };
+}
+
+/**
+ * Classify a list of files. The first MAX_IMAGE_COUNT supported
+ * images are returned as `ImageContent[]` (oversize and unsupported
+ * image types drop a notice); non-image files become `@<path>`
+ * references in `references`.
+ *
+ * Notice strings are user-facing (suitable for `setError` or a
+ * composer banner). Empty when nothing was skipped.
+ */
+export async function splitFilesForAttachment(
+  files: File[],
+): Promise<AttachmentSplit> {
+  const images: ImageContent[] = [];
+  const references: string[] = [];
+  const notices: string[] = [];
+  let imageSkipped = 0;
+  for (const f of files) {
+    if (isSupportedImage(f)) {
+      if (images.length >= MAX_IMAGE_COUNT) {
+        imageSkipped += 1;
+        continue;
+      }
+      if (f.size > MAX_IMAGE_BYTES) {
+        notices.push(
+          `图片过大（${formatBytes(f.size)} > ${formatBytes(MAX_IMAGE_BYTES)}），已跳过：${f.name}`,
+        );
+        continue;
+      }
+      try {
+        const content = await readFileAsImageContent(f);
+        if (content) {
+          images.push(content);
+          continue;
+        }
+        notices.push(`图片读取失败，已跳过：${f.name}`);
+      } catch {
+        notices.push(`图片读取失败，已跳过：${f.name}`);
+      }
+      continue;
+    }
+    // Non-image: append `@<path>` reference. Renderer-side path may
+    // be `file.path` (Electron exposes it on dropped files) or empty.
+    const path = (f as unknown as { path?: string }).path ?? f.name;
+    if (path) references.push(`@${path} `);
+  }
+  if (imageSkipped > 0) {
+    notices.push(`已达图片上限 ${MAX_IMAGE_COUNT} 张，跳过 ${imageSkipped} 张`);
+  }
+  return { images, references, notices };
+}
+
+function readAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ""));
+    reader.onerror = () =>
+      reject(reader.error ?? new Error("FileReader failed"));
+    reader.readAsDataURL(file);
+  });
+}
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  return `${(n / 1024 / 1024).toFixed(1)} MB`;
+}

--- a/apps/desktop/src/lib/file-attachment.ts
+++ b/apps/desktop/src/lib/file-attachment.ts
@@ -4,13 +4,13 @@
  * Three public entry points:
  * - `readFileAsImageContent(file)` —— read a single File, return
  *   ImageContent or null if the file isn't a supported image.
- * - `splitFilesForAttachment(files)` —— classify into images
- *   (returned) and non-image paths (returned for `@<path>` 注入
- *   input text by the caller).
+ * - `splitFilesForAttachment(items)` —— classify `{file, absPath}[]`
+ *   into images (returned) and references (returned as `<file>`
+ *   blocks appended to input text by the caller).
  * - `MAX_IMAGE_BYTES` / `MAX_IMAGE_COUNT` —— caller-side gates
  *   that match this module's enforcement.
  *
- * The renderer is the only consumer; the file payload is sent
+ * The renderer is the only consumer; the image payload is sent
  * over IPC as part of `PromptPayload.images`.
  */
 import type { ImageContent } from "../../shared/ipc";
@@ -29,11 +29,32 @@ export const MAX_IMAGE_BYTES = 4 * 1024 * 1024;
 /** Hard cap on the number of images per prompt. */
 export const MAX_IMAGE_COUNT = 4;
 
+/**
+ * Input to `splitFilesForAttachment`. The renderer pre-resolves the
+ * absolute path via `webUtils.getPathForFile(file)` (Electron 32+ no
+ * longer auto-attaches `file.path` for cross-origin security), and
+ * passes both the File and the absolute path so this module stays a
+ * pure function with no DOM/Electron coupling.
+ */
+export interface FileInput {
+  file: File;
+  /** Absolute path on disk. Empty string if Electron could not resolve. */
+  absPath: string;
+  /** Optional short name override (e.g. `f.name`) when absPath is empty. */
+  fallbackName?: string;
+}
+
 /** Result of splitting dropped / pasted files into image vs reference. */
 export interface AttachmentSplit {
   /** Image attachments ready to be added to `ImageContent[]`. */
   images: ImageContent[];
-  /** Paths / references that should be appended to the input text as `@<path>`. */
+  /**
+   * `<file name="<abs path>">\n</file>` blocks (empty content). Pushed
+   * into the composer input verbatim. User message renderer collapses
+   * these to a chip with basename + tooltip = full path. The absolute
+   * path is preserved in the `name` attribute so the model can use
+   * the `read` tool with the full path.
+   */
   references: string[];
   /** Notes for the user (skipped files with reasons). */
   notices: string[];
@@ -62,54 +83,79 @@ export async function readFileAsImageContent(
 }
 
 /**
- * Classify a list of files. The first MAX_IMAGE_COUNT supported
+ * Classify a list of file inputs. The first MAX_IMAGE_COUNT supported
  * images are returned as `ImageContent[]` (oversize and unsupported
- * image types drop a notice); non-image files become `@<path>`
- * references in `references`.
+ * image types drop a notice); non-image files become `<file>`
+ * reference blocks in `references`.
  *
  * Notice strings are user-facing (suitable for `setError` or a
  * composer banner). Empty when nothing was skipped.
  */
 export async function splitFilesForAttachment(
-  files: File[],
+  items: FileInput[],
 ): Promise<AttachmentSplit> {
   const images: ImageContent[] = [];
   const references: string[] = [];
   const notices: string[] = [];
   let imageSkipped = 0;
-  for (const f of files) {
-    if (isSupportedImage(f)) {
+  for (const { file, absPath, fallbackName } of items) {
+    const displayName = basename(absPath || fallbackName || file.name);
+    if (isSupportedImage(file)) {
       if (images.length >= MAX_IMAGE_COUNT) {
         imageSkipped += 1;
         continue;
       }
-      if (f.size > MAX_IMAGE_BYTES) {
+      if (file.size > MAX_IMAGE_BYTES) {
         notices.push(
-          `图片过大（${formatBytes(f.size)} > ${formatBytes(MAX_IMAGE_BYTES)}），已跳过：${f.name}`,
+          `图片过大（${formatBytes(file.size)} > ${formatBytes(MAX_IMAGE_BYTES)}），已跳过：${displayName}`,
         );
         continue;
       }
       try {
-        const content = await readFileAsImageContent(f);
+        const content = await readFileAsImageContent(file);
         if (content) {
           images.push(content);
           continue;
         }
-        notices.push(`图片读取失败，已跳过：${f.name}`);
+        notices.push(`图片读取失败，已跳过：${displayName}`);
       } catch {
-        notices.push(`图片读取失败，已跳过：${f.name}`);
+        notices.push(`图片读取失败，已跳过：${displayName}`);
       }
       continue;
     }
-    // Non-image: append `@<path>` reference. Renderer-side path may
-    // be `file.path` (Electron exposes it on dropped files) or empty.
-    const path = (f as unknown as { path?: string }).path ?? f.name;
-    if (path) references.push(`@${path} `);
+    // Non-image: emit `<file name="<abs path>">\n</file>` block. The
+    // block name carries the absolute path so the model can `read` it.
+    // expandAtPaths does not touch pre-existing `<file>` blocks, so
+    // this round-trips verbatim. The renderer collapses it to a chip
+    // showing the basename (full path in tooltip).
+    const ref = absPath || fallbackName || file.name;
+    if (!ref) {
+      notices.push(`文件无路径，已跳过：${file.name}`);
+      continue;
+    }
+    references.push(`<file name="${escapeAttr(ref)}">\n</file>`);
   }
   if (imageSkipped > 0) {
     notices.push(`已达图片上限 ${MAX_IMAGE_COUNT} 张，跳过 ${imageSkipped} 张`);
   }
   return { images, references, notices };
+}
+
+/** Cross-platform basename for the renderer (no `path` module available). */
+function basename(p: string): string {
+  if (!p) return "";
+  // Strip both Unix and Windows separators, take last segment.
+  const m = /([^/\\]+)[/\\]*$/.exec(p);
+  return m ? m[1]! : p;
+}
+
+/** Escape `<` / `>` / `"` / `&` for safe insertion into XML-ish attributes. */
+function escapeAttr(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/"/g, "&quot;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 function readAsDataUrl(file: File): Promise<string> {

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -6338,6 +6338,31 @@ body[data-session-type="design"] .composer-shell[data-streaming="true"] {
   display: block;
 }
 
+.composer-attachment-chip-file {
+  width: auto;
+  height: 56px;
+  min-width: 56px;
+  padding: 0 28px 0 10px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--bg-card);
+}
+
+.composer-attachment-file-icon {
+  color: var(--text-muted);
+  flex-shrink: 0;
+}
+
+.composer-attachment-file-name {
+  font-size: 12px;
+  color: var(--text-strong);
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .composer-attachment-remove {
   position: absolute;
   top: 2px;

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -2983,6 +2983,12 @@ body[data-session-type="design"] .chat-panel {
   border-color: color-mix(in srgb, var(--mode-color) 24%, transparent);
 }
 
+.composer-shell[data-dragover="true"] {
+  outline: 2px dashed var(--accent-blue);
+  outline-offset: -4px;
+  background: color-mix(in srgb, var(--accent-blue) 6%, var(--bg-card-elev));
+}
+
 /* 策划会话: composer shell 加策划色描边 + 浅色 glow, 不抢 mode pill 的颜色. */
 body[data-session-type="design"] .composer-shell {
   border-color: var(--session-design-accent, #d59c5b);
@@ -6305,4 +6311,57 @@ body[data-session-type="design"] .composer-shell[data-streaming="true"] {
   .logo-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
+}
+
+/* Composer attachments (#42): 粘贴截图 / 拖放图片的缩略图 + 计数 */
+.composer-attachments {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.composer-attachment-chip {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--board-line, var(--mode-color));
+  background: var(--bg-card);
+}
+
+.composer-attachment-thumb {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.composer-attachment-remove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: none;
+  background: color-mix(in srgb, var(--bg-card-elev) 85%, transparent);
+  color: var(--text-strong);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0;
+}
+
+.composer-attachment-remove:hover {
+  background: var(--mode-color);
+  color: var(--text-on-accent, var(--bg-card-elev));
+}
+
+.composer-attachments-count {
+  font-size: 11px;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
 }

--- a/apps/desktop/src/vite-env.d.ts
+++ b/apps/desktop/src/vite-env.d.ts
@@ -5,6 +5,9 @@ import type { XAgentApi } from "../shared/ipc";
 declare global {
   interface Window {
     xAgent: XAgentApi;
+    xAgentPath?: {
+      getForFile(file: File): string;
+    };
   }
 }
 

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -16,6 +16,13 @@ export default defineConfig({
       "shared/**/*.test.ts",
       "src/**/*.test.ts",
     ],
+    // 跳过 React 组件渲染测试 —— vitest 跑的是 node 环境, 没有 jsdom.
+    // ComposerAttachments.test.tsx 留在仓库作为手测脚手架; 核心逻辑 (file
+    // → ImageContent, 4 张 / 4MB / mimeType 校验) 由 src/lib/file-attachment.test.ts
+    // 覆盖.
+    exclude: [
+      "src/components/ComposerAttachments.test.tsx",
+    ],
     coverage: {
       provider: "v8",
       reporter: ["text", "html", "json-summary"],


### PR DESCRIPTION
## 标题

feat(attachments): composer 支持粘贴截图与拖放文件（含绝对路径 + chip 化）

## 背景

`D:\UGit\z-2` 项目里策划会话下，user 拖入 `D:\UGit\自走棋\config\01_chess_pieces.csv` 时遇到两个体验问题：

1. Electron 32+ 不再自动挂 `File.path`（出于 cross-origin drag 安全），拖入只 fallback 到 `f.name`（只是 basename），AI 拿到的是 cwd 内的相对路径解析结果，定位不到原始文件位置。
2. 即使后续切到 `<file name="<abs path>">` 块，input 文本（textarea 纯文本）里仍会显示完整绝对路径长串，对话历史 chip 才是短显示，UX 不一致。

本次一并解决：**绝对路径给 AI** + **短显示** + **跟图片附件同区域**。

## 变更摘要

### commit 1 — `feat(ipc)` (801752b)
- `shared/ipc.ts` — 新增 `ImageContent` / `PromptPayload` 类型；`IpcInvokeMap.prompt` 签名 `(text: string) → (payload: PromptPayload)`，images 可选
- `electron/preload.ts` — `api.prompt` 透传 payload
- `electron/agent/session-host.ts` — `prompt(payload)` 调 `session.prompt(text, { images, streamingBehavior })`；`SessionModeHost` / `RetractOrchestratorHost` 仍接 string（内部 wrap），controller 4 处调用不动
- `electron/ipc/register-turn-ipc.ts` — handler 接受 `PromptPayload`
- `src/App.tsx` — 两处 `window.xAgent.turn.prompt(text)` wrap 成 `{ text }`（commit 2 之前必须的 mechanical 迁移）
- `shared/ipc.test.ts` 新增 — 5 个不变量断言（payload 形状、JSON round-trip、3 态 PromptResult）

### commit 2 — `feat(renderer)` (9ae5a62)
- `src/lib/file-attachment.ts` 新增 — `readFileAsImageContent` / `splitFilesForAttachment` / `MAX_IMAGE_BYTES=4MB` / `MAX_IMAGE_COUNT=4` / `SUPPORTED_IMAGE_MIME = {png,jpeg,gif,webp}`
- `src/lib/file-attachment.test.ts` 新增 12 个断言
- `src/components/ComposerAttachments.tsx` 新增 — 缩略图 chip + 计数 + X 按钮
- `src/components/ComposerAttachments.test.tsx` 新增 — React 组件手测脚手架（vitest 是 node 环境跑不了 React 组件；`vitest.config.ts` exclude 它避免 CI 失败）
- `src/components/ChatPanel.tsx` — composer-shell 加 `onDragOver/Leave/Drop` + `data-dragover`；textarea 加 `onPaste` 拦截 `image/*` clipboard items
- `src/App.tsx` — `attachments` state 顶层维护；`send` snapshot attachments + 调 `setAttachments([])` 清空；`onAddFiles` / `onRemoveAttachment` 回调
- `src/styles/app.css` — `composer-shell[data-dragover="true"]` 虚线 outline + 浅蓝半透明；`.composer-attachments*` 系列
- `vitest.config.ts` — exclude `ComposerAttachments.test.tsx`

### commit 3 — `fix(attachments)` (88269d2)
- `electron/preload.ts` 暴露 `window.xAgentPath.getForFile`（内部 `webUtils.getPathForFile`）
- `src/lib/file-attachment.ts` — `splitFilesForAttachment` 接受 `FileInput[] = { file, absPath, fallbackName? }`；references 输出 `<file name="<abs path>">\n</file>` 块
- `src/vite-env.d.ts` — `xAgentPath?` 类型声明
- `src/App.tsx` onAddFiles — map File → FileInput，调 `window.xAgentPath.getForFile` 拿绝对路径
- `src/lib/file-attachment.test.ts` — 12 → 16 断言（绝对路径优先 / Windows 反斜杠 / XML attr 注入防御 / fallback 兜底）

### commit 4 — `feat(chat)` (057ef35)
- `src/components/UserMessageBody.tsx` — `FileRefChip` 改显示 `basename(name)` 短，完整绝对路径走 `title` + `aria-label`；空 content 时显示 "未展开" meta + 展开时显示完整路径
- 加跨平台 basename helper（renderer 没 `path` 模块）

### commit 5 — `fix(attachments)` (48f7a47)
- `src/lib/file-attachment.ts` — `references` 改 `FileReference[] = { absPath, displayName }`，不再生成 `<file>` 块 markup
- `src/lib/expandAtPaths.ts` — `expandAtPathsInPrompt(text, extraRefs)` 接受 `FileInput[]` 形式的额外引用，强制走绝对路径展开，读不到时产空 `<file>` 块（保留 name），拼到返回 text 末尾
- `src/App.tsx` — 新增 `fileRefs` state；onAddFiles 拼短串到 input + push 到 fileRefs；send snapshot 并清空，调 `expandAtPathsInPrompt(text, currentFileRefs)`
- `src/lib/file-attachment.test.ts` — 12 断言改为 `{absPath, displayName}` 结构 + 2 新断言

### commit 6 — `fix(attachments)` (bd17d8a)
- `src/components/ComposerAttachments.tsx` 重写 — 接 `fileRefs` + `onRemoveFile` props；图片 chip 不变；文件 chip 用 FileText 图标 + basename + X 按钮；计数行 `N/4 · M 文件`
- `src/components/ChatPanel.tsx` — 加 `fileRefs` / `onRemoveImage` / `onRemoveFile` props（替换 `onRemoveAttachment`）
- `src/App.tsx` — onAddFiles 不再 setInput 拼短串，改 setFileRefs；新增 onRemoveImage / onRemoveFile
- `src/styles/app.css` — `.composer-attachment-chip-file` 样式（auto 宽度容纳文件名 + FileText 图标）

## 最终 UX

| | input 文本 | composer 内部 | user message 渲染 | AI 拿到 |
|--|--|--|--|--|
| 图片附件 | （空） | 缩略图 chip + X | 内联 image content | image data |
| 文件附件 | （空） | 文件 chip（FileText + basename + X） | chip 短（basename + title 绝对路径） | `<file name="<abs path>">\n<content>\n</file>` 块（cwd 内 inline；cwd 外空 content 也保留 name） |

图片 + 文件附件完全对称：拖入 / 粘贴 → chip 化显示 → X 移除 → send 时携带。

## 影响面

**改的文件**（按 commit 分组）：
- commit 1：`shared/ipc.ts`、`shared/ipc.test.ts`、`electron/preload.ts`、`electron/agent/session-host.ts`、`electron/ipc/register-turn-ipc.ts`、`src/App.tsx`
- commit 2：`src/lib/file-attachment.ts`、`src/lib/file-attachment.test.ts`、`src/components/ComposerAttachments.tsx`、`src/components/ComposerAttachments.test.tsx`、`src/components/ChatPanel.tsx`、`src/App.tsx`、`src/styles/app.css`、`vitest.config.ts`
- commit 3：`electron/preload.ts`、`src/lib/file-attachment.ts`、`src/lib/file-attachment.test.ts`、`src/vite-env.d.ts`、`src/App.tsx`
- commit 4：`src/components/UserMessageBody.tsx`
- commit 5：`src/lib/file-attachment.ts`、`src/lib/expandAtPaths.ts`、`src/App.tsx`、`src/lib/file-attachment.test.ts`
- commit 6：`src/components/ComposerAttachments.tsx`、`src/components/ChatPanel.tsx`、`src/App.tsx`、`src/styles/app.css`

**不动**：
- `plan-mode-guard` / `design-write-guard` / `bash-readonly` — ImageContent 不走工具拦截
- `DESIGN_SESSION_TYPE_TOOLS` — 工具基线事实
- 已有 `@路径` 展开逻辑（仅扩展签名，行为兼容）
- `SessionModeController` 4 处 controller 内部 prompt 调用（仍接 string，host 内部 wrap）

## 测试与验收

### 自动化
- `npm run typecheck` ✓
- `npm run lint` ✓
- `npx vitest run` — **37 test files / 508 tests passed** (12s)
- 4 commits 累计新增 16 + 12 + 4 + 2 = 34 个新断言守不变量

### 端到端手测清单
1. **粘贴截图**：Snipaste 截一张图 → focus composer → `Ctrl+V` → composer 上方出现缩略图 chip
2. **拖放图片**：从文件管理器拖一张 `D:/foo.png` → composer 区域出现蓝色虚线高亮 → 松手 → 缩略图 chip
3. **拖放文件**（commit 6 重点）：拖 `D:/UGit/z-2/config/01_chess_pieces.csv` → composer 出现 `📄 01_chess_pieces.csv` chip（FileText 图标 + basename + X）
4. **混合拖入**：先拖图片再拖文件 → 两类 chip 同一行显示，计数行 `1/4 · 1 文件`
5. **X 移除**：点 chip 的 X → 移除该附件，send 时不再携带
6. **超限**：粘贴 5 张图 → chip 只显示 4 张 + notice
7. **超大**：粘贴 5MB PNG → "图片过大" notice
8. **绝对路径**：拖 cwd 外文件 → file chip 显示 basename，悬停 title 看到完整绝对路径，AI 拿到 `<file name="<abs path>">\n</file>` 块（cwd 外时 content 空但 name 完整）
9. **streaming 期间粘贴**：streaming 中 `Ctrl+V` 粘贴图 → 走 steer 路径，图片跟 steer text 一起发

## 回滚方案

按 commit 单独 revert 即可，互不耦合：
- commit 1（IPC 形状）：revert 整个 commit 6 个 commit，IPC 仍走 string
- commit 2 / 6（renderer UX）：revert 不影响 commit 1，IPC 形状不变
- commit 3 / 5（绝对路径）：revert 不影响 commit 2，仍可拖入但路径只到 fallback
- commit 4（chip 显示）：revert 不影响功能，对话历史只显示 basename 变全路径

## 后续未做（plan 边界外）

- 切到 React 富文本（Slate / Lexical）让 input 段也支持 file chip 渲染，去掉短串段 + file 段的双重显示
- 跨 editAndResend 携带附件
- attachments 跨会话持久化
- goal 模式 / plan mode build 携带附件
