### PR TITLE
fix(ci): dependabot-auto-merge race condition 加 3 次 5s 重试

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,7 +32,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: |
+          # `gh pr merge --auto` 偶发因 GraphQL race condition 失败
+          # (Protected branch rules not configured for this branch)。
+          # 典型场景: Dependabot 刚推 PR, branch protection 元数据未就绪。
+          # 简单重试 3 次, 每次等 5s, 覆盖 99% 的偶发情况。
+          for attempt in 1 2 3; do
+            if gh pr merge --auto --squash "$PR_URL"; then
+              echo "✅ auto-merge enabled on attempt $attempt"
+              exit 0
+            fi
+            echo "⚠️ attempt $attempt failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "❌ auto-merge failed after 3 attempts"
+          exit 1
 
       - name: Comment for non-patch (informational)
         if: |
@@ -42,4 +56,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr comment "$PR_URL" --body "🤖 Auto-merge skipped: \`${{ steps.meta.outputs.update-type }}\`. Patch-only auto-merge is enabled; minor/major updates need a human review."
+          # comment 是 informational, 失败不影响主流程; 但仍重试避免静默漏通知
+          for attempt in 1 2 3; do
+            if gh pr comment "$PR_URL" --body "🤖 Auto-merge skipped: \`${{ steps.meta.outputs.update-type }}\`. Patch-only auto-merge is enabled; minor/major updates need a human review."; then
+              exit 0
+            fi
+            echo "⚠️ comment attempt $attempt failed, retrying in 5s..."
+            sleep 5
+          done
+          echo "⚠️ comment failed after 3 attempts, but auto-merge logic is unaffected"


### PR DESCRIPTION
## 背景

\dependabot-auto-merge\ workflow 里的 \gh pr merge --auto --squash\ 偶发因 GraphQL race condition 失败:

\\\
GraphQL: Pull request Protected branch rules not configured for this branch (enablePullRequestAutoMerge)
\\\

典型场景: Dependabot 刚推 PR / 重新 push 触发 \synchronize\ 事件时, branch protection 元数据尚未在 GitHub 内部就绪。

**实际案例**: 2026-08-31 typebox #50 是 patch 升级, CI 全绿, 但 auto-merge run FAILURE, 留到 inbox 累积。

## 改动

两个 step 都加 3 次 5s 重试:

- \Enable auto-merge for semver-patch\ —— 失败会让 auto-merge 完全失效, 必须重试 + exit 1 兜底
- \Comment for non-patch\ —— comment 失败只影响通知, 重试后仍失败就 warn 但不 fail step

## 验收

- [ ] actionlint 通过
- [ ] 下次 Dependabot 提的 patch PR (例如 #46 #47 #49 #51 类型) 不会因 race condition 漏合
- [ ] Comment 通知在 race condition 下仍可靠投递