### PR TITLE
chore(deps): 升级 electron-vite 到 v6.0.0-beta.1 解锁 vite 8

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -30,7 +30,7 @@
         "diff": "^9.0.0",
         "electron": "^43.4.1",
         "electron-builder": "^26.15.3",
-        "electron-vite": "^5.0.0",
+        "electron-vite": "^6.0.0-beta.1",
         "tsx": "^4.23.12",
         "typescript": "^7.0.2",
         "vite": "^7.3.6",
@@ -43,6 +43,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -271,6 +272,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -2607,7 +2609,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -2629,7 +2630,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3887,6 +3887,7 @@
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4290,6 +4291,7 @@
       "integrity": "sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/utils": "4.1.11",
@@ -4865,13 +4867,13 @@
       }
     },
     "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-7.0.0.tgz",
+      "integrity": "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8"
+        "node": ">=20.19.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -5145,8 +5147,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5397,6 +5398,7 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -5579,17 +5581,17 @@
       }
     },
     "node_modules/electron-vite": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/electron-vite/-/electron-vite-5.0.0.tgz",
-      "integrity": "sha512-OHp/vjdlubNlhNkPkL/+3JD34ii5ov7M0GpuXEVdQeqdQ3ulvVR7Dg/rNBLfS5XPIFwgoBLDf9sjjrL+CuDyRQ==",
+      "version": "6.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/electron-vite/-/electron-vite-6.0.0-beta.1.tgz",
+      "integrity": "sha512-jltST77AwNxIeTTDtYhnIEA8ZM0RW9jmSJcqS8x/dQcgeeLlxlcJoYNNJ1tv7/Swor0AbXMYteBGdezoAOt+Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.28.4",
+        "@babel/core": "^7.29.0",
         "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "cac": "^6.7.14",
+        "cac": "^7.0.0",
         "esbuild": "^0.25.11",
-        "magic-string": "^0.30.19",
+        "magic-string": "^0.30.21",
         "picocolors": "^1.1.1"
       },
       "bin": {
@@ -5600,7 +5602,7 @@
       },
       "peerDependencies": {
         "@swc/core": "^1.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@swc/core": {
@@ -5615,7 +5617,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5636,7 +5637,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5652,7 +5652,6 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -5663,7 +5662,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -7826,7 +7824,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -8149,6 +8146,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -8285,7 +8283,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -8303,7 +8300,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8420,6 +8416,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8429,6 +8426,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8643,7 +8641,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9048,7 +9045,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -9926,6 +9922,7 @@
       "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
@@ -10468,6 +10465,7 @@
       "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.11",
         "@vitest/mocker": "4.1.11",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -59,7 +59,7 @@
     "diff": "^9.0.0",
     "electron": "^43.4.1",
     "electron-builder": "^26.15.3",
-    "electron-vite": "^5.0.0",
+    "electron-vite": "^6.0.0-beta.1",
     "tsx": "^4.23.12",
     "typescript": "^7.0.2",
     "vite": "^7.3.6",


### PR DESCRIPTION
## 背景

解锁 vite 8 / @vitejs/plugin-react 6 升级的前置条件：

| 阻塞项 | 旧 | 新 |
|---|---|---|
| `electron-vite` peer | `vite@^5 \|\| ^6 \|\| ^7` | `vite@^6 \|\| ^7 \|\| ^8` |

依赖升级链路：
1. **本 PR**：`electron-vite@5.0.0` → `electron-vite@6.0.0-beta.1` ✅
2. 下一个 PR：`vite@7.3.6` → `vite@8.2.2`（重新打开 #48）
3. 再下一个 PR：`@vitejs/plugin-react@5.2.0` → `6.1.0`（重新打开 #53）

## breaking change 评估

`electron-vite@6.0.0-beta.1` 的变化：

- **`"type": "module"`（ESM only）**——项目本身已是 ESM（`apps/desktop/package.json` line 12），无需调整
- **dist 路径仍是 `./dist/index.js`**——现有 `import { defineConfig, externalizeDepsPlugin } from "electron-vite"` 兼容
- **engines.node 升到 `^20.19.0 || >=22.12.0`**——项目用 Node 22+，满足
- **peer `@swc/core` optional**——不影响

## 验证

本地（master + 此 PR）：

- [x] `npm install` 成功（removed 4 / changed 23 packages）
- [x] `npm run typecheck` 通过
- [x] `npm run test:unit` 526/527 pass（1 fail 预存在：本地 bash PATH 缺 Git Bash 致 `bash-check.test.ts` timeout，CI runner 不受影响）

CI 流程验证：

- [ ] actionlint
- [ ] desktop (typecheck + test + lint + build)
- [ ] unit-test
- [ ] e2e (Playwright smoke)

## 风险

`electron-vite@6.0.0-beta.1` 是 beta 版（非 stable），理论上有：
- 子依赖 (`@babel/core` / `esbuild` / `picocolors` 等) 版本大跳——已 `npm install` 验证 lock 可解
- 主进程 / preload 的 build 行为变化——`electron.vite.config.ts` 用的是保守 API (`externalizeDepsPlugin` + `rollupOptions`)，影响应可控
- electron-vite@5→6 的真实使用差异需 `npm run build` + 启动 Electron 验证（CI 跑 build 但不启动 app，需本地手动跑 `npm run dev`）

## 解锁后

合并后：
- 重新打开 #48 (vite 7→8)，合一次 PR → 验证 CI
- 重新打开 #53 (plugin-react 5→6)，合一次 PR → 验证 CI
- 关闭 #54

## 参考

- electron-vite@6.0.0-beta.1: https://www.npmjs.com/package/electron-vite/v/6.0.0-beta.1
- electron-vite upstream: https://github.com/alex8088/electron-vite
- 关联: #54 (追踪 issue), #48 (vite, blocked), #53 (plugin-react, blocked)
