### PR TITLE
refactor(session): 收口 host-bag 为 4 窄 interface (主题 A #59 C-104/C-108)

### DIFF
--- a/apps/desktop/electron/agent/host-interfaces.ts
+++ b/apps/desktop/electron/agent/host-interfaces.ts
@@ -1,0 +1,118 @@
+/**
+ * SessionHost 暴露给 3 个子编排器 (SessionLifecycle / SessionModeController /
+ * RetractOrchestrator) 的窄 interface 集合. 2026-08-31 收口 (issue #59 主题 A):
+ *
+ * 之前 3 个 host-bag 适配器 (asLifecycleAccess / asModeHost / asRetractHost) 在
+ * session-host.ts:151-223 直接返回 22/8/10 字段的对象,leverage ≈ 0.
+ * 现拆为 4 个按关注点切分的 interface,子编排器只 import 自己需要的.
+ *
+ * 接口边界 (而非 "host bag" 大对象) 的好处:
+ * - 子编排器可独立单测 (mock 4 个 interface 即可,不必造整个 SessionHost)
+ * - typecheck 立即捕获"加了字段忘更新某 orchestrator"
+ * - 关注点分离: 资源 / 事件 / cwd / 运行时各归各位
+ */
+import type {
+  AgentSession,
+  DefaultResourceLoader,
+  ModelRuntime,
+} from "@earendil-works/pi-coding-agent";
+import type {
+  AgentStatus,
+  HistoryItem,
+  NoticeReplaceKey,
+  PromptPayload,
+  PromptResult,
+  TurnUsage,
+  UiAgentEvent,
+} from "../../shared/ipc";
+import type { SessionBundle } from "./session-lifecycle";
+import type { TurnFileTracker } from "./turn-file-tracker";
+import type { ShadowCheckpointTracker } from "./shadow-checkpoints";
+import type { SessionModeController } from "./session-mode";
+import type { GodotRpcBridge } from "./godot-rpc-bridge";
+import type { ToolDetailRecord } from "./session-host-helpers";
+
+/** 资源只读视图: bundle / loader / basePrompt / 子 tracker / 子 controller. */
+export interface ResourceState {
+  getBundle(): SessionBundle | null;
+  getResourceLoader(): DefaultResourceLoader | null;
+  getBaseAppendPrompt(): string[];
+  fileTracker: TurnFileTracker;
+  shadowCheckpoints: ShadowCheckpointTracker;
+  sessionMode: SessionModeController;
+  godotRpc: GodotRpcBridge | null;
+  /** Last assistant turn token total (0 if unknown). */
+  getLastTurnTokenTotal(): number;
+  /** Active user turn entry id (for goal budget ledger), if any. */
+  getActiveUserEntryId(): string | null;
+}
+
+/** 事件总线: emit / notice / status / usage / history replace. */
+export interface EventBus {
+  emit(event: UiAgentEvent): void;
+  emitReplaceableNotice(
+    replaceKey: NoticeReplaceKey,
+    text: string,
+    level?: "info" | "warn" | "error",
+  ): void;
+  setStatus(status: AgentStatus, error?: string): void;
+  emitUsageUpdate(): void;
+  emitHistoryReplace(): void;
+}
+
+/** Cwd-orchestrating operations: bridge events / runtime / prompt. */
+export interface CwdOps {
+  pruneToolDetailsToBranch(): void;
+  ensureRuntime(): Promise<ModelRuntime>;
+  bridgeEvents(session: AgentSession): () => void;
+  prompt(payload: PromptPayload | string): Promise<PromptResult>;
+  /** True while a prompt is mid-flight (model call in progress). */
+  promptPreparing: boolean;
+  isPromptPreparing(): boolean;
+}
+
+/** 运行时状态: 互斥运行 / 指纹 / tool 详情 / 可变状态 setter / retract 回调. */
+export interface RuntimeState {
+  runReplaceExclusive<T>(fn: () => Promise<T>): Promise<T>;
+  historyFingerprint(items: HistoryItem[]): string;
+  toolDetails: Map<string, ToolDetailRecord>;
+  // Mutable state setters
+  setBundle(bundle: SessionBundle | null): void;
+  setResourceLoader(loader: DefaultResourceLoader | null): void;
+  setBaseAppendPrompt(base: string[]): void;
+  setLastTurnUsage(u: TurnUsage | undefined): void;
+  clearCompactionState(): void;
+  setAutoTitleInFlight(v: boolean): void;
+  setLastHistoryFingerprint(fp: string | null): void;
+  /** Retract orchestrator 完成后通知 sessionMode rollback goal. */
+  onRetractSuccess(abandonedUserEntryIds: string[]): void;
+}
+
+// ============ 3 个子编排器专用窄类型 ============
+// SessionHost 用 Pick<> 组合 4 个 interface 后传给对应子编排器.
+// 子编排器只 import 自己需要的 type,看不到 host 全貌.
+
+/** SessionLifecycle: 唯一同时拿到 ResourceState + EventBus + CwdOps + RuntimeState
+ *  全量的子编排器. 负责 open / resume / dispose / createSession 完整生命周期. */
+export type SessionLifecycleHost = ResourceState & EventBus & CwdOps & RuntimeState;
+
+/** SessionModeController: 4 case 模式互锁,只需要读资源 + emit notice + prompt + ensureRuntime. */
+export type SessionModeHost = Pick<
+  ResourceState,
+  | "getBundle"
+  | "getResourceLoader"
+  | "getBaseAppendPrompt"
+  | "getLastTurnTokenTotal"
+  | "getActiveUserEntryId"
+> &
+  Pick<EventBus, "emit" | "emitReplaceableNotice"> &
+  Pick<CwdOps, "ensureRuntime" | "prompt">;
+
+/** RetractOrchestrator: 撤回 pipeline,需要 bundle/tracker + status/history + prompt + onRetractSuccess. */
+export type RetractOrchestratorHost = Pick<
+  ResourceState,
+  "getBundle" | "fileTracker" | "shadowCheckpoints"
+> &
+  Pick<EventBus, "setStatus" | "emitHistoryReplace" | "emitUsageUpdate"> &
+  Pick<CwdOps, "pruneToolDetailsToBranch" | "prompt" | "promptPreparing" | "isPromptPreparing"> &
+  Pick<RuntimeState, "onRetractSuccess">;

--- a/apps/desktop/electron/agent/retract-orchestrator.ts
+++ b/apps/desktop/electron/agent/retract-orchestrator.ts
@@ -4,34 +4,21 @@
  */
 import type { AgentSession } from "@earendil-works/pi-coding-agent";
 import type {
-  AgentStatus,
   RetractOptions,
   RetractPreview,
   RetractResult,
 } from "../../shared/ipc";
 import { extractMessageText } from "../../shared/transcript";
-import type { TurnFileTracker } from "./turn-file-tracker";
-import type { ShadowCheckpointTracker } from "./shadow-checkpoints";
 import { CompositeRestoreSource } from "./restore-source";
+import type { RetractOrchestratorHost } from "./host-interfaces";
 
 export type RetractSessionBundle = {
   session: AgentSession;
 };
 
-export type RetractOrchestratorHost = {
-  getBundle(): RetractSessionBundle | null;
-  fileTracker: TurnFileTracker;
-  shadowCheckpoints: ShadowCheckpointTracker;
-  setStatus(status: AgentStatus, error?: string): void;
-  pruneToolDetailsToBranch(): void;
-  emitHistoryReplace(): void;
-  emitUsageUpdate(): void;
-  prompt(text: string): Promise<{ ok: boolean; error?: string }>;
-  /** True while prompt() is between checkpoint prepare and session.prompt. */
-  isPromptPreparing?(): boolean;
-  /** Called after successful navigate + restore so Goal budget can roll back. */
-  onRetractSuccess?(abandonedUserEntryIds: readonly string[]): void;
-};
+// RetractOrchestratorHost 类型从 ./host-interfaces 导入 (issue #59 主题 A 收口).
+// 本地不再手抄, 与新 4 interface (ResourceState/EventBus/CwdOps/RuntimeState)
+// 的 Pick<> 组合保持单一源.
 
 export type ResolvedUserEntry =
   | { ok: true; entryId: string; editorText: string }

--- a/apps/desktop/electron/agent/session-host.ts
+++ b/apps/desktop/electron/agent/session-host.ts
@@ -18,6 +18,7 @@ import {
   type HistoryItem,
   type HostStatus,
   type ModelInfo,
+  type NoticeReplaceKey,
   type OpenProjectResult,
   type PlanContentResult,
   type PlanMutateResult,
@@ -55,12 +56,10 @@ import { wrapPromptSlashAsBlock } from "./prompt-slash-wrap";
 import { buildSessionSlashItems } from "./session-slash-items";
 import {
   SessionModeController,
-  type SessionModeHost,
   isReadonlySessionMode,
 } from "./session-mode/index";
 import {
   RetractOrchestrator,
-  type RetractOrchestratorHost,
 } from "./retract-orchestrator";
 import { TurnFileTracker } from "./turn-file-tracker";
 import { ShadowCheckpointTracker } from "./shadow-checkpoints";
@@ -75,8 +74,16 @@ import {
 import {
   SessionLifecycle,
   type SessionBundle,
-  type SessionLifecycleAccess,
 } from "./session-lifecycle";
+import type {
+  CwdOps,
+  EventBus,
+  ResourceState,
+  RuntimeState,
+  SessionLifecycleHost,
+  SessionModeHost,
+  RetractOrchestratorHost,
+} from "./host-interfaces";
 import {
   bridgeSessionEvents,
   type SessionEventBridgeDeps,
@@ -103,7 +110,7 @@ export class SessionHost {
    * would corrupt turn state / resurrect stale pre SHAs). Retract rejects
    * while this flag is set.
    */
-  private promptPreparing = false;
+  promptPreparing = false;
   private lastError: string | undefined;
   private getWindow: () => BrowserWindow | null;
   private godotRpc: GodotRpcBridge | null;
@@ -141,16 +148,105 @@ export class SessionHost {
   ) {
     this.getWindow = getWindow;
     this.godotRpc = godotRpc;
-    this.sessionMode = new SessionModeController(() => this.asModeHost());
+    this.sessionMode = new SessionModeController(() => this.asSessionModeHost());
     this.retractOrchestrator = new RetractOrchestrator(() =>
-      this.asRetractHost(),
+      this.asRetractOrchestratorHost(),
     );
-    this.lifecycle = new SessionLifecycle(() => this.asLifecycleAccess());
+    this.lifecycle = new SessionLifecycle(() => this.asSessionLifecycleHost());
   }
 
-  private asLifecycleAccess(): SessionLifecycleAccess {
+  // ============ 4 个窄 host-bag 暴露 (issue #59 主题 A) ============
+  // 替代 asLifecycleAccess / asModeHost / asRetractHost 3 个大 host-bag.
+  // SessionLifecycle 拿到 4 件全量; Mode / Retract 只 Pick 自己要的.
+
+  /** Full host for SessionLifecycle (open/resume/dispose 全生命周期). */
+  private asSessionLifecycleHost(): SessionLifecycleHost {
+    return {
+      ...this.asResourceState(),
+      ...this.asEventBus(),
+      ...this.asCwdOps(),
+      ...this.asRuntimeState(),
+    };
+  }
+
+  /** Narrow host for SessionModeController (mode 互锁路径). */
+  private asSessionModeHost(): SessionModeHost {
     return {
       getBundle: () => this.bundle,
+      getResourceLoader: () => this.getResourceLoader(),
+      getBaseAppendPrompt: () => this.getBaseAppendPrompt(),
+      getLastTurnTokenTotal: () => this.lastTurnUsage?.tokens.total ?? 0,
+      getActiveUserEntryId: () => this.fileTracker.getActiveUserEntryId(),
+      emit: (event) => this.emit(event),
+      emitReplaceableNotice: (replaceKey, text, level) =>
+        this.emitReplaceableNotice(replaceKey, text, level),
+      ensureRuntime: () => this.ensureRuntime(),
+      prompt: (payload) =>
+        this.prompt(typeof payload === "string" ? { text: payload } : payload),
+    };
+  }
+
+  /** Narrow host for RetractOrchestrator (撤回 pipeline). */
+  private asRetractOrchestratorHost(): RetractOrchestratorHost {
+    return {
+      getBundle: () => this.bundle,
+      fileTracker: this.fileTracker,
+      shadowCheckpoints: this.shadowCheckpoints,
+      setStatus: (status, error) => this.setStatus(status, error),
+      emitHistoryReplace: () => this.emitHistoryReplace(),
+      emitUsageUpdate: () => this.emitUsageUpdate(),
+      pruneToolDetailsToBranch: () => this.pruneToolDetailsToBranch(),
+      prompt: (payload) =>
+        this.prompt(typeof payload === "string" ? { text: payload } : payload),
+      promptPreparing: this.promptPreparing,
+      isPromptPreparing: () => this.promptPreparing,
+      onRetractSuccess: (abandonedUserEntryIds) =>
+        this.sessionMode.rollbackGoalAfterRetract(abandonedUserEntryIds),
+    };
+  }
+
+  private asResourceState(): ResourceState {
+    return {
+      getBundle: () => this.bundle,
+      getResourceLoader: () => this.getResourceLoader(),
+      getBaseAppendPrompt: () => this.getBaseAppendPrompt(),
+      fileTracker: this.fileTracker,
+      shadowCheckpoints: this.shadowCheckpoints,
+      sessionMode: this.sessionMode,
+      godotRpc: this.godotRpc,
+      getLastTurnTokenTotal: () => this.lastTurnUsage?.tokens.total ?? 0,
+      getActiveUserEntryId: () => this.fileTracker.getActiveUserEntryId(),
+    };
+  }
+
+  private asEventBus(): EventBus {
+    return {
+      emit: (event) => this.emit(event),
+      emitReplaceableNotice: (replaceKey, text, level) =>
+        this.emitReplaceableNotice(replaceKey, text, level),
+      setStatus: (status, error) => this.setStatus(status, error),
+      emitUsageUpdate: () => this.emitUsageUpdate(),
+      emitHistoryReplace: () => this.emitHistoryReplace(),
+    };
+  }
+
+  private asCwdOps(): CwdOps {
+    return {
+      pruneToolDetailsToBranch: () => this.pruneToolDetailsToBranch(),
+      ensureRuntime: () => this.ensureRuntime(),
+      bridgeEvents: (session) => this.bridgeEvents(session),
+      prompt: (payload) =>
+        this.prompt(typeof payload === "string" ? { text: payload } : payload),
+      promptPreparing: this.promptPreparing,
+      isPromptPreparing: () => this.promptPreparing,
+    };
+  }
+
+  private asRuntimeState(): RuntimeState {
+    return {
+      runReplaceExclusive: (fn) => this.runReplaceExclusive(fn),
+      historyFingerprint: (items) => this.historyFingerprint(items),
+      toolDetails: this.toolDetails,
       setBundle: (bundle) => {
         this.bundle = bundle;
       },
@@ -173,50 +269,6 @@ export class SessionHost {
       setLastHistoryFingerprint: (fp) => {
         this.lastHistoryFingerprint = fp;
       },
-      toolDetails: this.toolDetails,
-      fileTracker: this.fileTracker,
-      shadowCheckpoints: this.shadowCheckpoints,
-      sessionMode: this.sessionMode,
-      godotRpc: this.godotRpc,
-      runReplaceExclusive: (fn) => this.runReplaceExclusive(fn),
-      ensureRuntime: () => this.ensureRuntime(),
-      bridgeEvents: (session) => this.bridgeEvents(session),
-      emit: (event) => this.emit(event),
-      emitReplaceableNotice: (replaceKey, notice, level) =>
-        this.emitReplaceableNotice(replaceKey, notice, level),
-      setStatus: (status, error) => this.setStatus(status, error),
-      emitUsageUpdate: () => this.emitUsageUpdate(),
-      historyFingerprint: (items) => this.historyFingerprint(items),
-    };
-  }
-
-  /** Host bag for SessionModeController: session + emit + prompt + runtime. */
-  private asModeHost(): SessionModeHost {
-    return {
-      getBundle: () => this.getBundle(),
-      getResourceLoader: () => this.getResourceLoader(),
-      getBaseAppendPrompt: () => this.getBaseAppendPrompt(),
-      emit: (event) => this.emit(event),
-      emitReplaceableNotice: (replaceKey, text, level) =>
-        this.emitReplaceableNotice(replaceKey, text, level),
-      prompt: (text) => this.prompt({ text }),
-      ensureRuntime: () => this.ensureRuntime(),
-      getLastTurnTokenTotal: () => this.lastTurnUsage?.tokens.total ?? 0,
-      getActiveUserEntryId: () => this.fileTracker.getActiveUserEntryId(),
-    };
-  }
-
-  private asRetractHost(): RetractOrchestratorHost {
-    return {
-      getBundle: () => this.bundle,
-      fileTracker: this.fileTracker,
-      shadowCheckpoints: this.shadowCheckpoints,
-      setStatus: (status, error) => this.setStatus(status, error),
-      pruneToolDetailsToBranch: () => this.pruneToolDetailsToBranch(),
-      emitHistoryReplace: () => this.emitHistoryReplace(),
-      emitUsageUpdate: () => this.emitUsageUpdate(),
-      prompt: (text) => this.prompt({ text }),
-      isPromptPreparing: () => this.promptPreparing,
       onRetractSuccess: (abandonedUserEntryIds) =>
         this.sessionMode.rollbackGoalAfterRetract(abandonedUserEntryIds),
     };
@@ -634,15 +686,7 @@ export class SessionHost {
    * Same replaceKey replaces the previous bubble (mode / model / tools / …).
    */
   private emitReplaceableNotice(
-    replaceKey:
-      | "session_mode"
-      | "model"
-      | "tools"
-      | "resources"
-      | "plan"
-      | "goal_eval"
-      | "session"
-      | "extension",
+    replaceKey: NoticeReplaceKey,
     text: string,
     level: "info" | "warn" | "error" = "info",
   ): void {

--- a/apps/desktop/electron/agent/session-lifecycle.ts
+++ b/apps/desktop/electron/agent/session-lifecycle.ts
@@ -13,14 +13,11 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import {
   SESSION_TOOL_REGISTRY,
-  type AgentStatus,
   type ClientPrefs,
   type HistoryItem,
   type OpenProjectResult,
   type SessionInfo,
   type ThinkingLevel,
-  type TurnUsage,
-  type UiAgentEvent,
 } from "../../shared/ipc";
 import {
   DEFAULT_SESSION_TYPE,
@@ -33,7 +30,6 @@ import { getCachedPrefs, patchPrefs } from "./prefs";
 import { branchEntriesToHistory } from "../../shared/transcript";
 import { getXAgentSessionsRoot, isXAgentSessionPath } from "./session-paths";
 import { displaySessionName } from "./session-title";
-import type { GodotRpcBridge } from "./godot-rpc-bridge";
 import { createGodotTools } from "./godot-tools";
 import { dbgLog } from "../../shared/debug-log";
 import {
@@ -46,7 +42,6 @@ import {
   computeModeToolsForType,
   createWritePlanTools,
   createPlanModeGuardExtension,
-  type SessionModeController,
 } from "./session-mode/index";
 import {
   createDesignWriteGuardExtension,
@@ -56,8 +51,6 @@ import {
   loadSessionType,
   saveSessionType,
 } from "./session-type-persistence";
-import type { TurnFileTracker } from "./turn-file-tracker";
-import type { ShadowCheckpointTracker } from "./shadow-checkpoints";
 import {
   normalizeProjectKey,
   pickFallbackSessionPath,
@@ -68,8 +61,8 @@ import { ensureBuiltinDesignSkillsInstalledSafe } from "./builtin-skills-install
 import {
   failOpen,
   modelFromSession,
-  type ToolDetailRecord,
 } from "./session-host-helpers";
+import type { SessionLifecycleHost } from "./host-interfaces";
 
 export type SessionBundle = {
   session: AgentSession;
@@ -80,48 +73,11 @@ export type SessionBundle = {
   sessionType: SessionType;
 };
 
-/** Mutable state + services SessionLifecycle needs from SessionHost. */
-export type SessionLifecycleAccess = {
-  getBundle(): SessionBundle | null;
-  setBundle(bundle: SessionBundle | null): void;
-  setResourceLoader(loader: DefaultResourceLoader | null): void;
-  setBaseAppendPrompt(base: string[]): void;
-  setLastTurnUsage(u: TurnUsage | undefined): void;
-  clearCompactionState(): void;
-  setAutoTitleInFlight(v: boolean): void;
-  setLastHistoryFingerprint(fp: string | null): void;
-  toolDetails: Map<string, ToolDetailRecord>;
-  fileTracker: TurnFileTracker;
-  shadowCheckpoints: ShadowCheckpointTracker;
-  sessionMode: SessionModeController;
-  godotRpc: GodotRpcBridge | null;
-  runReplaceExclusive<T>(fn: () => Promise<T>): Promise<T>;
-  ensureRuntime(): Promise<ModelRuntime>;
-  bridgeEvents(session: AgentSession): () => void;
-  emit(event: UiAgentEvent): void;
-  emitReplaceableNotice(
-    replaceKey:
-      | "session_mode"
-      | "model"
-      | "tools"
-      | "resources"
-      | "plan"
-      | "goal_eval"
-      | "session"
-      | "extension",
-    text: string,
-    level?: "info" | "warn" | "error",
-  ): void;
-  setStatus(status: AgentStatus, error?: string): void;
-  emitUsageUpdate(): void;
-  historyFingerprint(items: HistoryItem[]): string;
-};
-
 export class SessionLifecycle {
-  constructor(private readonly getAccess: () => SessionLifecycleAccess) {}
+  constructor(private readonly getHost: () => SessionLifecycleHost) {}
 
-  private a(): SessionLifecycleAccess {
-    return this.getAccess();
+  private a(): SessionLifecycleHost {
+    return this.getHost();
   }
 
   private sessionFileOf(session: AgentSession): string | null {

--- a/apps/desktop/electron/agent/session-mode/controller.ts
+++ b/apps/desktop/electron/agent/session-mode/controller.ts
@@ -10,7 +10,6 @@ import type {
   PromptResult,
   SessionModeInfo,
   SessionModeResult,
-  UiAgentEvent,
 } from "../../../shared/ipc";
 import {
   DEFAULT_GOAL_MAX_TOKENS,
@@ -59,36 +58,10 @@ import {
   buildPlanModeSystemAppend,
 } from "../../../shared/mode-prompt";
 import { dbgLog } from "../../../shared/debug-log";
+import type { SessionModeHost } from "../host-interfaces";
 
-export type SessionModeHost = {
-  getBundle(): {
-    session: AgentSession;
-    cwd: string;
-    sessionPath?: string | null;
-    sessionType?: SessionType;
-  } | null;
-  getResourceLoader(): DefaultResourceLoader | null;
-  getBaseAppendPrompt(): string[];
-  emit(event: UiAgentEvent): void;
-  emitReplaceableNotice(
-    replaceKey:
-      | "session_mode"
-      | "model"
-      | "tools"
-      | "resources"
-      | "plan"
-      | "goal_eval"
-      | "session",
-    text: string,
-    level?: "info" | "warn" | "error",
-  ): void;
-  prompt(text: string): Promise<PromptResult>;
-  ensureRuntime(): Promise<ModelRuntime>;
-  /** Last assistant turn token total (0 if unknown). */
-  getLastTurnTokenTotal(): number;
-  /** Active user turn entry id (for goal budget ledger), if any. */
-  getActiveUserEntryId(): string | null;
-};
+// SessionModeHost 类型从 ../host-interfaces 导入 (issue #59 主题 A 收口).
+// 本地不再手抄, 避免 controller.ts:73-81 漏 "extension" 之类 drift 复发.
 
 type GoalTurnLedgerEntry = {
   /** User entry that started the agent turn being evaluated. */

--- a/apps/desktop/electron/agent/session-mode/index.ts
+++ b/apps/desktop/electron/agent/session-mode/index.ts
@@ -2,10 +2,9 @@
  * 会话模式 — Ask / Plan / Goal lifecycle (main process).
  * External callers should import from this index.
  */
-export {
-  SessionModeController,
-  type SessionModeHost,
-} from "./controller";
+export { SessionModeController } from "./controller";
+// SessionModeHost 类型从 ../host-interfaces 导出 (issue #59 主题 A 收口).
+export type { SessionModeHost } from "../host-interfaces";
 export {
   computeAskModeTools,
   computePlanModeTools,

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -674,8 +674,26 @@ export type HistoryItem =
       text: string;
       level?: "info" | "warn" | "error";
       /** When set, a later notice with the same key replaces this bubble. */
-      replaceKey?: string;
+      replaceKey?: NoticeReplaceKey;
     };
+
+/**
+ * Stable keys for "replaceable" notice bubbles (mode / model / tools / …).
+ * Same key replaces the previous bubble in the transcript; different keys stack.
+ *
+ * Single source — host bag 子编排器都 import 这一个,避免 drift.
+ * 2026-08-31 收口 (issue #59 主题 A C-108). 之前 lifecycle.ts / controller.ts
+ * / session-host.ts 3 处手抄,controller 还漏了 "extension".
+ */
+export type NoticeReplaceKey =
+  | "session_mode"
+  | "model"
+  | "tools"
+  | "resources"
+  | "plan"
+  | "goal_eval"
+  | "session"
+  | "extension";
 
 export type FileRestoreSkipReason =
   | "bash_unknown"
@@ -852,7 +870,7 @@ export type UiAgentEvent =
        * Same-key notices replace the previous bubble in the transcript
        * (e.g. session mode switches) instead of stacking.
        */
-      replaceKey?: string;
+      replaceKey?: NoticeReplaceKey;
     }
   | {
       type: "session_title";


### PR DESCRIPTION
## 主题 A: session-host 3 host-bag 适配器拆分 (issue #59)

### 变更摘要

session-host.ts 的 3 个 host-bag 适配器 (`asLifecycleAccess` / `asModeHost` / `asRetractHost`) 返回 22/8/10 字段对象,leverage ≈ 0. 现拆为 4 个按关注点切分的 interface,子编排器只 import 自己需要的.

**4 个窄 interface** (`electron/agent/host-interfaces.ts`):

| Interface | 关注点 | 关键字段 |
|---|---|---|
| `ResourceState` | 资源只读 | bundle / loader / basePrompt / fileTracker / shadowCheckpoints / sessionMode / godotRpc / lastTurnToken / activeEntryId |
| `EventBus` | 事件总线 | emit / emitReplaceableNotice / setStatus / emitUsageUpdate / emitHistoryReplace |
| `CwdOps` | cwd 编排 | pruneToolDetailsToBranch / ensureRuntime / bridgeEvents / prompt / promptPreparing |
| `RuntimeState` | 运行时状态 | runReplaceExclusive / historyFingerprint / toolDetails / 可变 setter / onRetractSuccess |

**3 个子编排器各取所需**:
- `SessionLifecycle` → `SessionLifecycleHost = ResourceState & EventBus & CwdOps & RuntimeState` (全量)
- `SessionModeController` → `SessionModeHost = Pick<ResourceState, ...> & Pick<EventBus, ...> & Pick<CwdOps, ...>` (5+2+2 = 9 字段)
- `RetractOrchestrator` → `RetractOrchestratorHost = Pick<ResourceState, ...> & Pick<EventBus, ...> & Pick<CwdOps, ...> & Pick<RuntimeState, 'onRetractSuccess'>` (3+3+4+1 = 11 字段)

### 附: 类型 drift 收口

- **`shared/ipc.ts` 新增 `NoticeReplaceKey` type** (8 联合),3 处手抄合并为单源
  - `session-lifecycle.ts` / `session-mode/controller.ts` / `session-host.ts` 原手抄版本
  - 修复 `controller.ts:73-81` 漏 `"extension"` 的 drift
- **`shared/ipc.ts` `UiAgentEvent.notice.replaceKey` 改用 `NoticeReplaceKey`** (ChatItem.system.replaceKey 同步)
- `controller.ts` / `retract-orchestrator.ts` 删本地 host-bag type (改 import 自 host-interfaces,避免 drift 复发)
- `session-lifecycle.ts` 22 字段 `SessionLifecycleAccess` 类型整段删
- `session-mode/index.ts` 改 type-only re-export `SessionModeHost`

### 收益

- 3 子编排器可独立单测 (mock 4 interface 即可,不必造整个 SessionHost)
- typecheck 立即捕获"加了字段忘更新某 orchestrator"
- 关注点分离: 资源 / 事件 / cwd / 运行时各归各位
- `session-lifecycle.ts`: -52 行, `session-mode/controller.ts`: -33 行
- `session-host.ts`: +166/-166 行 (3 host-bag 变 4 窄 adapter + ResourceState 等)
- 净 +95 行 (其中 host-interfaces.ts 新增 3.5KB)

### 验收

- [x] `npm run typecheck`: 0 errors
- [x] `npx vitest run`: 41 files / 531 tests pass (无新 case, 纯重构)
- [x] 既有 `session-mode-controller` / `retract-orchestrator` / `session-host-helpers` 单测全过

### 不在本 PR (留给 PR-Y2 / 后续)

- 主题 A 的 C-102 (session-host 跨域 host-bag 泄漏 — 与 C-104 重叠,本 PR 已解决) + C-401 — 已收口
- 主题 B (controller 1078 行 + 4 case commit 模板) — 下一 PR-Y2

Refs #59 (主题 A)
