### PR TITLE
refactor(ipc): sender-untrust 抛契约化异常 + typeguard (主题 H #65)

### DIFF
--- a/apps/desktop/electron/ipc/register-ipc.test.ts
+++ b/apps/desktop/electron/ipc/register-ipc.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { DELETED_FLAT_KEYS } from "../../shared/ipc";
+import {
+  DELETED_FLAT_KEYS,
+  isSenderUntrustedError,
+} from "../../shared/ipc";
 import { IPC_CHANNELS } from "../../shared/ipc-channels";
-import { handle } from "./register-ipc";
+import { configureIpcSenderGuard, handle } from "./register-ipc";
 
 describe("ipc channel registry", () => {
   it("key names equal channel values (preload generation depends on this)", () => {
@@ -40,5 +43,74 @@ describe("handle registrar", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]![0]).toBe(IPC_CHANNELS.newSession);
     await expect(calls[0]![1]()).resolves.toBe(result);
+  });
+});
+
+describe("isSenderUntrustedError typeguard (issue #65 主题 H)", () => {
+  it("识别 __senderUntrusted: true + channel: string 结构", () => {
+    const err = { __senderUntrusted: true, channel: "prompt" };
+    expect(isSenderUntrustedError(err)).toBe(true);
+  });
+
+  it("拒绝普通 Error (无 __senderUntrusted tag)", () => {
+    expect(isSenderUntrustedError(new Error("业务错误"))).toBe(false);
+    expect(isSenderUntrustedError(new Error("IPC 调用来源不受信任"))).toBe(false);
+  });
+
+  it("拒绝 null / undefined / 字符串", () => {
+    expect(isSenderUntrustedError(null)).toBe(false);
+    expect(isSenderUntrustedError(undefined)).toBe(false);
+    expect(isSenderUntrustedError("error")).toBe(false);
+  });
+
+  it("拒绝 tag 在但 channel 不是 string", () => {
+    expect(isSenderUntrustedError({ __senderUntrusted: true, channel: 123 })).toBe(false);
+    expect(isSenderUntrustedError({ __senderUntrusted: true })).toBe(false);
+  });
+
+  it("拒绝 __senderUntrusted 不是 boolean true", () => {
+    expect(isSenderUntrustedError({ __senderUntrusted: "yes", channel: "x" })).toBe(false);
+    expect(isSenderUntrustedError({ __senderUntrusted: false, channel: "x" })).toBe(false);
+  });
+});
+
+describe("sender guard 集成 (issue #65 主题 H)", () => {
+  it("不可信 sender 抛 SenderUntrustedError 契约, handler 不被调", async () => {
+    // mock 主窗口: 真实 webContents 与事件 senderFrame 不匹配
+    const fakeWin = { webContents: { id: 1 }, isDestroyed: () => false };
+    configureIpcSenderGuard(() => fakeWin as never, null);
+
+    const calls: Array<[string, (...args: unknown[]) => unknown]> = [];
+    const ipcMain = {
+      handle: vi.fn((c: string, f: never) => calls.push([c, f])),
+    };
+    const handler = vi.fn(async () => ({ ok: true }));
+
+    handle(ipcMain as never, IPC_CHANNELS.prompt, handler as never);
+
+    expect(calls).toHaveLength(1);
+    const registered = calls[0]![1];
+
+    // mock 不可信 sender: 不同的 webContents
+    const untrustedEvent = {
+      sender: { id: 999 }, // 不同于 fakeWin.webContents
+      senderFrame: { url: "file:///something" },
+    };
+    let caught: unknown;
+    try {
+      await (registered as (e: unknown) => Promise<unknown>)(untrustedEvent);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(isSenderUntrustedError(caught)).toBe(true);
+    if (isSenderUntrustedError(caught)) {
+      expect(caught.__senderUntrusted).toBe(true);
+      expect(caught.channel).toBe(IPC_CHANNELS.prompt);
+    }
+    expect(handler).not.toHaveBeenCalled();
+
+    // 清理 guard
+    configureIpcSenderGuard(() => null, null);
   });
 });

--- a/apps/desktop/electron/ipc/register-ipc.ts
+++ b/apps/desktop/electron/ipc/register-ipc.ts
@@ -3,7 +3,11 @@ import type {
   IpcMain,
   IpcMainInvokeEvent,
 } from "electron";
-import type { IpcInvokeMap, IpcChannelKey } from "../../shared/ipc";
+import {
+  type IpcInvokeMap,
+  type IpcChannelKey,
+  type SenderUntrustedError,
+} from "../../shared/ipc";
 
 /**
  * Typed `ipcMain.handle` registrar: the handler signature is derived from
@@ -13,6 +17,10 @@ import type { IpcInvokeMap, IpcChannelKey } from "../../shared/ipc";
  * Every handler is wrapped with a sender trust check (defense in depth):
  * only the main window's webContents (and a frame whose origin matches the
  * renderer URL / file: protocol) may invoke channels.
+ *
+ * 不可信 sender 现在抛 `SenderUntrustedError` (issue #65 主题 H, 2026-08-31),
+ * renderer 端可用 `isSenderUntrustedError` typeguard 区分. 不再加进 IpcInvokeMap[K]
+ * (会让 100+ consumer 全部 typecheck 失败, 详见 SenderUntrustedError doc).
  */
 export type IpcHandler<K extends IpcChannelKey> = IpcInvokeMap[K] extends (
   ...args: infer Args
@@ -66,7 +74,14 @@ export function handle<K extends IpcChannelKey>(
   ipcMain.handle(channel, (event, ...args) => {
     if (!isTrustedIpcSender(event as IpcMainInvokeEvent)) {
       console.warn(`[ipc] 拒绝来自不受信任来源的调用：${channel}`);
-      throw new Error("IPC 调用来源不受信任");
+      // 抛契约化异常 (issue #65 主题 H, 2026-08-31). 之前 throw new Error(...)
+      // 让 renderer 端 catch 块拿到普通 Error, 无法与业务错误区分. 现在用
+      // __senderUntrusted tag 让 typeguard 识别, channel 字段方便日志追踪.
+      const err: SenderUntrustedError = {
+        __senderUntrusted: true,
+        channel,
+      };
+      throw err;
     }
     return handler(event, ...args);
   });

--- a/apps/desktop/shared/ipc-invoke-map.ts
+++ b/apps/desktop/shared/ipc-invoke-map.ts
@@ -82,6 +82,37 @@ export type WorkspaceApi = {
   getStatus: IpcInvokeMap["getStatus"];
 };
 
+/**
+ * 不可信 sender 异常契约 (issue #65 主题 H, 2026-08-31).
+ *
+ * 之前 register-ipc.ts 在 sender trust 校验失败时 throw `new Error("IPC 调用来源不受信任")`,
+ * renderer 端 catch 块拿到的是普通 Error, 无法与业务错误区分.
+ *
+ * 现在抛契约化异常, renderer 可用 `isSenderUntrustedError(e)` typeguard 判断.
+ * 字段 `__senderUntrusted: true` 是 tag (类似 fp-ts 的 Discriminated Union),
+ * 不会被业务 Result 误判. `channel` 字段方便日志追踪是哪个 IPC 通道拒绝.
+ *
+ * 不在 IpcInvokeMap[K] 联合类型中加这个变体: 那样会让 100+ 个 renderer consumer
+ * 全部 typecheck 失败 (Result 多了一个无 `.ok` 字段的变体). 当前只把契约暴露给
+ * sender guard 测试 + 给未来 IpcInvokeMap 二次改造留 hook. 详见 register-ipc.ts.
+ */
+export interface SenderUntrustedError {
+  readonly __senderUntrusted: true;
+  readonly channel: string;
+}
+
+/** Typeguard: e 是 register-ipc.ts 抛的不可信 sender 异常. */
+export function isSenderUntrustedError(
+  e: unknown,
+): e is SenderUntrustedError {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    (e as { __senderUntrusted?: unknown }).__senderUntrusted === true &&
+    typeof (e as { channel?: unknown }).channel === "string"
+  );
+}
+
 /** Coarse turn / composer facade (facade methods stay on window.xAgent). */
 export type TurnApi = {
   prompt: IpcInvokeMap["prompt"];

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -23,7 +23,9 @@ export {
   type XAgentApiFlat,
   type XAgentApi,
   type DeletedFlatKey,
+  type SenderUntrustedError,
   DELETED_FLAT_KEYS,
+  isSenderUntrustedError,
 } from "./ipc-invoke-map";
 
 import { Type } from "typebox";


### PR DESCRIPTION
## 主题 H: sender-untrust 抛契约化异常 (issue #65)

### 变更摘要

之前 `register-ipc.ts:67-70` 在 sender trust 校验失败时 throw `new Error("IPC 调用来源不受信任")`, renderer 端 catch 块拿到普通 Error, 无法与业务错误区分. 现在:

- `shared/ipc-invoke-map.ts` 新增 `SenderUntrustedError` 接口 + `isSenderUntrustedError` typeguard
  - 字段 `__senderUntrusted: true` 是 tag (类似 fp-ts Discriminated Union)
  - 字段 `channel: string` 方便日志追踪是哪个 IPC 通道被拒
- `shared/ipc.ts` barrel re-export (向后兼容 104 个 consumer)
- `register-ipc.ts:67-74` 改为抛 `{ __senderUntrusted: true, channel }` 契约化对象
- `electron/ipc/register-ipc.test.ts` 新增 6 case:
  - `isSenderUntrustedError` 5 case (识别 / 拒绝普通 Error / 拒绝 null / 拒绝非 string channel / 拒绝非 boolean tag)
  - sender guard 集成 1 case (mock 不可信 sender, 验证抛契约化异常 + handler 不被调)

### 调整 vs 计划 (PR-Y5 计划)

- **计划说**: "每个 `IpcInvokeMap[K]` 返回类型 union `Result | SenderUntrustedError`"
- **实际**: 不在 `IpcInvokeMap[K]` 联合类型中加这个变体
  - 理由: 这样会让 100+ renderer consumer 全部 typecheck 失败 (Result 多了一个无 `.ok` 字段的变体, 所有 `result.ok` 访问都会 typecheck 报错)
  - 本次只把契约暴露给 sender guard 测试 + 留 hook 给未来 IpcInvokeMap 二次改造
  - 验收里 "IpcInvokeMap[K] 类型含 sender-trust 错误变体" 不完全满足, 但 runtime 行为已契约化 (`isSenderUntrustedError` typeguard + `SenderUntrustedError` 类型)

### 收益

- 契约化异常: typeguard 可识别, 与业务错误区分
- channel 字段: 日志可追踪是哪个 IPC 通道被拒
- 6 个新 vitest case 锁住契约
- vitest 41 files / 541 tests pass (从 535 增 6)

### 验收

- [x] `npm run typecheck`: 0 errors
- [x] `npx vitest run`: 41 files / 541 tests pass
- [x] `register-ipc.test.ts`: 10 case (4 旧 + 6 新)

Refs #65 (主题 H) - sender trust 契约化完成
