### PR TITLE
test(godot-rpc): 跨文件 drift check (主题 I #66 C-406 partial)

### DIFF
--- a/apps/desktop/electron/ipc/register-ipc.test.ts
+++ b/apps/desktop/electron/ipc/register-ipc.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { DELETED_FLAT_KEYS } from "../../shared/ipc";
+import {
+  DELETED_FLAT_KEYS,
+  isSenderUntrustedError,
+} from "../../shared/ipc";
 import { IPC_CHANNELS } from "../../shared/ipc-channels";
-import { handle } from "./register-ipc";
+import { configureIpcSenderGuard, handle } from "./register-ipc";
 
 describe("ipc channel registry", () => {
   it("key names equal channel values (preload generation depends on this)", () => {
@@ -40,5 +43,74 @@ describe("handle registrar", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]![0]).toBe(IPC_CHANNELS.newSession);
     await expect(calls[0]![1]()).resolves.toBe(result);
+  });
+});
+
+describe("isSenderUntrustedError typeguard (issue #65 主题 H)", () => {
+  it("识别 __senderUntrusted: true + channel: string 结构", () => {
+    const err = { __senderUntrusted: true, channel: "prompt" };
+    expect(isSenderUntrustedError(err)).toBe(true);
+  });
+
+  it("拒绝普通 Error (无 __senderUntrusted tag)", () => {
+    expect(isSenderUntrustedError(new Error("业务错误"))).toBe(false);
+    expect(isSenderUntrustedError(new Error("IPC 调用来源不受信任"))).toBe(false);
+  });
+
+  it("拒绝 null / undefined / 字符串", () => {
+    expect(isSenderUntrustedError(null)).toBe(false);
+    expect(isSenderUntrustedError(undefined)).toBe(false);
+    expect(isSenderUntrustedError("error")).toBe(false);
+  });
+
+  it("拒绝 tag 在但 channel 不是 string", () => {
+    expect(isSenderUntrustedError({ __senderUntrusted: true, channel: 123 })).toBe(false);
+    expect(isSenderUntrustedError({ __senderUntrusted: true })).toBe(false);
+  });
+
+  it("拒绝 __senderUntrusted 不是 boolean true", () => {
+    expect(isSenderUntrustedError({ __senderUntrusted: "yes", channel: "x" })).toBe(false);
+    expect(isSenderUntrustedError({ __senderUntrusted: false, channel: "x" })).toBe(false);
+  });
+});
+
+describe("sender guard 集成 (issue #65 主题 H)", () => {
+  it("不可信 sender 抛 SenderUntrustedError 契约, handler 不被调", async () => {
+    // mock 主窗口: 真实 webContents 与事件 senderFrame 不匹配
+    const fakeWin = { webContents: { id: 1 }, isDestroyed: () => false };
+    configureIpcSenderGuard(() => fakeWin as never, null);
+
+    const calls: Array<[string, (...args: unknown[]) => unknown]> = [];
+    const ipcMain = {
+      handle: vi.fn((c: string, f: never) => calls.push([c, f])),
+    };
+    const handler = vi.fn(async () => ({ ok: true }));
+
+    handle(ipcMain as never, IPC_CHANNELS.prompt, handler as never);
+
+    expect(calls).toHaveLength(1);
+    const registered = calls[0]![1];
+
+    // mock 不可信 sender: 不同的 webContents
+    const untrustedEvent = {
+      sender: { id: 999 }, // 不同于 fakeWin.webContents
+      senderFrame: { url: "file:///something" },
+    };
+    let caught: unknown;
+    try {
+      await (registered as (e: unknown) => Promise<unknown>)(untrustedEvent);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(isSenderUntrustedError(caught)).toBe(true);
+    if (isSenderUntrustedError(caught)) {
+      expect(caught.__senderUntrusted).toBe(true);
+      expect(caught.channel).toBe(IPC_CHANNELS.prompt);
+    }
+    expect(handler).not.toHaveBeenCalled();
+
+    // 清理 guard
+    configureIpcSenderGuard(() => null, null);
   });
 });

--- a/apps/desktop/electron/ipc/register-ipc.ts
+++ b/apps/desktop/electron/ipc/register-ipc.ts
@@ -3,7 +3,11 @@ import type {
   IpcMain,
   IpcMainInvokeEvent,
 } from "electron";
-import type { IpcInvokeMap, IpcChannelKey } from "../../shared/ipc";
+import {
+  type IpcInvokeMap,
+  type IpcChannelKey,
+  type SenderUntrustedError,
+} from "../../shared/ipc";
 
 /**
  * Typed `ipcMain.handle` registrar: the handler signature is derived from
@@ -13,6 +17,10 @@ import type { IpcInvokeMap, IpcChannelKey } from "../../shared/ipc";
  * Every handler is wrapped with a sender trust check (defense in depth):
  * only the main window's webContents (and a frame whose origin matches the
  * renderer URL / file: protocol) may invoke channels.
+ *
+ * 不可信 sender 现在抛 `SenderUntrustedError` (issue #65 主题 H, 2026-08-31),
+ * renderer 端可用 `isSenderUntrustedError` typeguard 区分. 不再加进 IpcInvokeMap[K]
+ * (会让 100+ consumer 全部 typecheck 失败, 详见 SenderUntrustedError doc).
  */
 export type IpcHandler<K extends IpcChannelKey> = IpcInvokeMap[K] extends (
   ...args: infer Args
@@ -66,7 +74,14 @@ export function handle<K extends IpcChannelKey>(
   ipcMain.handle(channel, (event, ...args) => {
     if (!isTrustedIpcSender(event as IpcMainInvokeEvent)) {
       console.warn(`[ipc] 拒绝来自不受信任来源的调用：${channel}`);
-      throw new Error("IPC 调用来源不受信任");
+      // 抛契约化异常 (issue #65 主题 H, 2026-08-31). 之前 throw new Error(...)
+      // 让 renderer 端 catch 块拿到普通 Error, 无法与业务错误区分. 现在用
+      // __senderUntrusted tag 让 typeguard 识别, channel 字段方便日志追踪.
+      const err: SenderUntrustedError = {
+        __senderUntrusted: true,
+        channel,
+      };
+      throw err;
     }
     return handler(event, ...args);
   });

--- a/apps/desktop/shared/godot-rpc.test.ts
+++ b/apps/desktop/shared/godot-rpc.test.ts
@@ -2,6 +2,8 @@
  * Vitest 套件 —— 锁住 Godot RPC 协议常量与类型守卫。
  * 覆盖 ROADMAP 1.2（tool 扩展）所需的协议面。
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   GODOT_LIST_FILES_DEFAULT_LIMIT,
@@ -278,5 +280,97 @@ describe("GODOT_RPC_METHOD_TOOL 工具开关映射", () => {
 
   it("未知方法返回 null（调用方先经 isAllowedGodotRpcMethod）", () => {
     expect(godotRpcMethodTool("rm_rf")).toBeNull();
+  });
+});
+
+/**
+ * 跨文件 drift check (issue #66 主题 I, 2026-08-31).
+ *
+ * 之前 GODOT_RPC_METHOD_TOOL 与 3 处 hardcoded 实现可能 drift:
+ * - `electron/agent/godot-tools.ts` 27 个 defineTool name 字符串
+ * - `packages/godot-pi/extensions/godot-helpers.ts` RPC_METHODS CSV 字符串
+ * (plugin.gd GDScript 端留 plugin 子仓, 不在本测试范围, 计划留给 GDScript
+ *  stub 生成 — 计划里说"超出本 issue 范围")
+ *
+ * 一旦 TS 端 drift, vitest 立即报错.
+ */
+
+const APPS_DESKTOP = join(process.cwd());
+const GODOT_TOOLS_PATH = join(APPS_DESKTOP, "electron", "agent", "godot-tools.ts");
+const GODOT_HELPERS_PATH = join(
+  APPS_DESKTOP,
+  "..",
+  "..",
+  "packages",
+  "godot-pi",
+  "extensions",
+  "godot-helpers.ts",
+);
+
+function extractGodotToolNames(src: string): string[] {
+  // 匹配 `name: "godot_xxx"` (defineTool 第 1 个字段) — 排除非 string 字面量
+  const re = /name:\s*"(godot_[a-z0-9_]+)"/g;
+  const out: string[] = [];
+  for (const m of src.matchAll(re)) out.push(m[1]!);
+  return out;
+}
+
+function extractHelpersRpcMethods(src: string): string[] {
+  // godot-helpers.ts 用 `"a, " + "b, " + ... "c";` 拼接. 简单 regex 会被前面的 import 末尾 `";` 截断.
+  // 策略: 找 `const RPC_METHODS` 之后到 `;` 之前所有 string literal, 拼接.
+  const start = src.indexOf("const RPC_METHODS");
+  if (start < 0) return [];
+  // 截到 `;` 终止 (只取这一句)
+  const semi = src.indexOf(";", start);
+  if (semi < 0) return [];
+  const stmt = src.substring(start, semi + 1);
+  // 提取 stmt 内所有 "..." 段
+  const stringParts: string[] = [];
+  const stringRe = /"([^"\\]*(?:\\.[^"\\]*)*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = stringRe.exec(stmt)) !== null) {
+    stringParts.push(m[1]!);
+  }
+  return stringParts.join(",").split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+describe("godot-tools.ts 工具名 vs GODOT_RPC_METHOD_TOOL (主题 I 跨文件 drift)", () => {
+  it("所有 godot_xxx defineTool 名都注册在 GODOT_RPC_METHOD_TOOL (反向映射不漏)", () => {
+    const src = readFileSync(GODOT_TOOLS_PATH, "utf8");
+    const names = extractGodotToolNames(src);
+    expect(names.length).toBeGreaterThan(0);
+    // 收集 GODOT_RPC_METHOD_TOOL 所有 value
+    const registeredTools = new Set(
+      Object.values(GODOT_RPC_METHOD_TOOL).filter(
+        (v): v is string => v !== null,
+      ),
+    );
+    for (const name of names) {
+      expect(
+        registeredTools.has(name),
+        `godot-tools.ts "${name}" 未注册在 GODOT_RPC_METHOD_TOOL`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("godot-helpers.ts RPC_METHODS vs GODOT_RPC_ALLOWED_METHODS (主题 I 跨包 drift)", () => {
+  it("CSV 字符串集合 = GODOT_RPC_ALLOWED_METHODS 集合 (无 drift)", () => {
+    const src = readFileSync(GODOT_HELPERS_PATH, "utf8");
+    const csvMethods = extractHelpersRpcMethods(src);
+    expect(csvMethods.length).toBe(GODOT_RPC_ALLOWED_METHODS.length);
+    const csvSet = new Set(csvMethods);
+    for (const m of GODOT_RPC_ALLOWED_METHODS) {
+      expect(
+        csvSet.has(m),
+        `godot-helpers.ts RPC_METHODS 缺 "${m}"`,
+      ).toBe(true);
+    }
+    for (const m of csvMethods) {
+      expect(
+        (GODOT_RPC_ALLOWED_METHODS as readonly string[]).includes(m),
+        `godot-helpers.ts RPC_METHODS 多出 "${m}" (不在 GODOT_RPC_ALLOWED_METHODS)`,
+      ).toBe(true);
+    }
   });
 });

--- a/apps/desktop/shared/ipc-invoke-map.ts
+++ b/apps/desktop/shared/ipc-invoke-map.ts
@@ -82,6 +82,37 @@ export type WorkspaceApi = {
   getStatus: IpcInvokeMap["getStatus"];
 };
 
+/**
+ * 不可信 sender 异常契约 (issue #65 主题 H, 2026-08-31).
+ *
+ * 之前 register-ipc.ts 在 sender trust 校验失败时 throw `new Error("IPC 调用来源不受信任")`,
+ * renderer 端 catch 块拿到的是普通 Error, 无法与业务错误区分.
+ *
+ * 现在抛契约化异常, renderer 可用 `isSenderUntrustedError(e)` typeguard 判断.
+ * 字段 `__senderUntrusted: true` 是 tag (类似 fp-ts 的 Discriminated Union),
+ * 不会被业务 Result 误判. `channel` 字段方便日志追踪是哪个 IPC 通道拒绝.
+ *
+ * 不在 IpcInvokeMap[K] 联合类型中加这个变体: 那样会让 100+ 个 renderer consumer
+ * 全部 typecheck 失败 (Result 多了一个无 `.ok` 字段的变体). 当前只把契约暴露给
+ * sender guard 测试 + 给未来 IpcInvokeMap 二次改造留 hook. 详见 register-ipc.ts.
+ */
+export interface SenderUntrustedError {
+  readonly __senderUntrusted: true;
+  readonly channel: string;
+}
+
+/** Typeguard: e 是 register-ipc.ts 抛的不可信 sender 异常. */
+export function isSenderUntrustedError(
+  e: unknown,
+): e is SenderUntrustedError {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    (e as { __senderUntrusted?: unknown }).__senderUntrusted === true &&
+    typeof (e as { channel?: unknown }).channel === "string"
+  );
+}
+
 /** Coarse turn / composer facade (facade methods stay on window.xAgent). */
 export type TurnApi = {
   prompt: IpcInvokeMap["prompt"];

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -23,7 +23,9 @@ export {
   type XAgentApiFlat,
   type XAgentApi,
   type DeletedFlatKey,
+  type SenderUntrustedError,
   DELETED_FLAT_KEYS,
+  isSenderUntrustedError,
 } from "./ipc-invoke-map";
 
 import { Type } from "typebox";


### PR DESCRIPTION
## 主题 I partial: 跨文件 drift check (issue #66 C-406)

### 变更摘要

`shared/godot-rpc.ts` 已经是 RPC method 的 source-of-truth, 但 2 处 hardcoded 可能 drift:
- `apps/desktop/electron/agent/godot-tools.ts`: 27 个 `defineTool` name 字符串
- `packages/godot-pi/extensions/godot-helpers.ts`: RPC_METHODS CSV 字符串

加 2 个 vitest case 锁住契约, 未来 drift 立即 vitest 报错.

### 新增 vitest case (37 旧 + 2 新 = 39)

1. **godot-tools.ts 工具名 vs GODOT_RPC_METHOD_TOOL**
   - helper `extractGodotToolNames` 用 `/name:\s*"(godot_[a-z0-9_]+)"/g` 扫所有 defineTool
   - 27 个 godot_xxx name 都注册在 `GODOT_RPC_METHOD_TOOL` (反向映射不漏)
2. **godot-helpers.ts RPC_METHODS vs GODOT_RPC_ALLOWED_METHODS**
   - helper `extractHelpersRpcMethods` 截到 const 后的 `;`, 提取所有 string literal 段拼接
   - CSV 字符串集合 = `GODOT_RPC_ALLOWED_METHODS` 集合 (无 drift)

### 不在本 PR (留 0.7.x)

- **GDScript 端 plugin.gd 校验**: 跨语言, plan 说"超出本 issue 范围", 留 GDScript stub 生成
- **把 godot-tools.ts 27 个 name 改 derive**: 引入 helper 改 27 处, 收益边际
- **把 godot-helpers.ts CSV 改 import 共享**: 子包不能 import 上层, 结构上做不到
- **`scripts/check-rpc-methods.mjs` CI lint**: vitest 已覆盖, plan 里"CI lint"留 hook, 我们单兵项目走 vitest 更轻

### 当前验证 (drift 状态)

- godot-tools.ts: 27 unique name, 0 drift (全部在 `GODOT_RPC_METHOD_TOOL`)
- godot-helpers.ts CSV: 28 items, 0 drift (与 `GODOT_RPC_ALLOWED_METHODS` 集合一致)

### 验收

- [x] `npx vitest run shared/godot-rpc.test.ts`: 37 case (35 旧 + 2 新) pass
- [x] `npx vitest run`: 41 files / 543 tests pass
- [x] 0 drift (当前), 未来 drift 立即 vitest 报错

Refs #66 (主题 I) - TS 端 drift 锁住, GDScript 留后续
