### PR TITLE
refactor(electron): main.ts 拆 4 module + 收口 (主题 E #62 C-303+C-402)

### DIFF
--- a/apps/desktop/electron/ipc/register-ipc.test.ts
+++ b/apps/desktop/electron/ipc/register-ipc.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
-import { DELETED_FLAT_KEYS } from "../../shared/ipc";
+import {
+  DELETED_FLAT_KEYS,
+  isSenderUntrustedError,
+} from "../../shared/ipc";
 import { IPC_CHANNELS } from "../../shared/ipc-channels";
-import { handle } from "./register-ipc";
+import { configureIpcSenderGuard, handle } from "./register-ipc";
 
 describe("ipc channel registry", () => {
   it("key names equal channel values (preload generation depends on this)", () => {
@@ -40,5 +43,74 @@ describe("handle registrar", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0]![0]).toBe(IPC_CHANNELS.newSession);
     await expect(calls[0]![1]()).resolves.toBe(result);
+  });
+});
+
+describe("isSenderUntrustedError typeguard (issue #65 主题 H)", () => {
+  it("识别 __senderUntrusted: true + channel: string 结构", () => {
+    const err = { __senderUntrusted: true, channel: "prompt" };
+    expect(isSenderUntrustedError(err)).toBe(true);
+  });
+
+  it("拒绝普通 Error (无 __senderUntrusted tag)", () => {
+    expect(isSenderUntrustedError(new Error("业务错误"))).toBe(false);
+    expect(isSenderUntrustedError(new Error("IPC 调用来源不受信任"))).toBe(false);
+  });
+
+  it("拒绝 null / undefined / 字符串", () => {
+    expect(isSenderUntrustedError(null)).toBe(false);
+    expect(isSenderUntrustedError(undefined)).toBe(false);
+    expect(isSenderUntrustedError("error")).toBe(false);
+  });
+
+  it("拒绝 tag 在但 channel 不是 string", () => {
+    expect(isSenderUntrustedError({ __senderUntrusted: true, channel: 123 })).toBe(false);
+    expect(isSenderUntrustedError({ __senderUntrusted: true })).toBe(false);
+  });
+
+  it("拒绝 __senderUntrusted 不是 boolean true", () => {
+    expect(isSenderUntrustedError({ __senderUntrusted: "yes", channel: "x" })).toBe(false);
+    expect(isSenderUntrustedError({ __senderUntrusted: false, channel: "x" })).toBe(false);
+  });
+});
+
+describe("sender guard 集成 (issue #65 主题 H)", () => {
+  it("不可信 sender 抛 SenderUntrustedError 契约, handler 不被调", async () => {
+    // mock 主窗口: 真实 webContents 与事件 senderFrame 不匹配
+    const fakeWin = { webContents: { id: 1 }, isDestroyed: () => false };
+    configureIpcSenderGuard(() => fakeWin as never, null);
+
+    const calls: Array<[string, (...args: unknown[]) => unknown]> = [];
+    const ipcMain = {
+      handle: vi.fn((c: string, f: never) => calls.push([c, f])),
+    };
+    const handler = vi.fn(async () => ({ ok: true }));
+
+    handle(ipcMain as never, IPC_CHANNELS.prompt, handler as never);
+
+    expect(calls).toHaveLength(1);
+    const registered = calls[0]![1];
+
+    // mock 不可信 sender: 不同的 webContents
+    const untrustedEvent = {
+      sender: { id: 999 }, // 不同于 fakeWin.webContents
+      senderFrame: { url: "file:///something" },
+    };
+    let caught: unknown;
+    try {
+      await (registered as (e: unknown) => Promise<unknown>)(untrustedEvent);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(isSenderUntrustedError(caught)).toBe(true);
+    if (isSenderUntrustedError(caught)) {
+      expect(caught.__senderUntrusted).toBe(true);
+      expect(caught.channel).toBe(IPC_CHANNELS.prompt);
+    }
+    expect(handler).not.toHaveBeenCalled();
+
+    // 清理 guard
+    configureIpcSenderGuard(() => null, null);
   });
 });

--- a/apps/desktop/electron/ipc/register-ipc.ts
+++ b/apps/desktop/electron/ipc/register-ipc.ts
@@ -3,7 +3,11 @@ import type {
   IpcMain,
   IpcMainInvokeEvent,
 } from "electron";
-import type { IpcInvokeMap, IpcChannelKey } from "../../shared/ipc";
+import {
+  type IpcInvokeMap,
+  type IpcChannelKey,
+  type SenderUntrustedError,
+} from "../../shared/ipc";
 
 /**
  * Typed `ipcMain.handle` registrar: the handler signature is derived from
@@ -13,6 +17,10 @@ import type { IpcInvokeMap, IpcChannelKey } from "../../shared/ipc";
  * Every handler is wrapped with a sender trust check (defense in depth):
  * only the main window's webContents (and a frame whose origin matches the
  * renderer URL / file: protocol) may invoke channels.
+ *
+ * 不可信 sender 现在抛 `SenderUntrustedError` (issue #65 主题 H, 2026-08-31),
+ * renderer 端可用 `isSenderUntrustedError` typeguard 区分. 不再加进 IpcInvokeMap[K]
+ * (会让 100+ consumer 全部 typecheck 失败, 详见 SenderUntrustedError doc).
  */
 export type IpcHandler<K extends IpcChannelKey> = IpcInvokeMap[K] extends (
   ...args: infer Args
@@ -66,7 +74,14 @@ export function handle<K extends IpcChannelKey>(
   ipcMain.handle(channel, (event, ...args) => {
     if (!isTrustedIpcSender(event as IpcMainInvokeEvent)) {
       console.warn(`[ipc] 拒绝来自不受信任来源的调用：${channel}`);
-      throw new Error("IPC 调用来源不受信任");
+      // 抛契约化异常 (issue #65 主题 H, 2026-08-31). 之前 throw new Error(...)
+      // 让 renderer 端 catch 块拿到普通 Error, 无法与业务错误区分. 现在用
+      // __senderUntrusted tag 让 typeguard 识别, channel 字段方便日志追踪.
+      const err: SenderUntrustedError = {
+        __senderUntrusted: true,
+        channel,
+      };
+      throw err;
     }
     return handler(event, ...args);
   });

--- a/apps/desktop/electron/main-debug.ts
+++ b/apps/desktop/electron/main-debug.ts
@@ -1,0 +1,116 @@
+/**
+ * Debug 模式 + DevTools 工具 (主题 E #62 PR-Y7 拆分, 2026-08-31).
+ *
+ * - debug mode 检测: CLI 参数 (--x-agent-debug / --debug-ui) + 环境变量 X_AGENT_DEBUG
+ *   未打包运行时默认开启, 打包后仅在显式开启
+ * - DevTools 独立窗口: openDebugTools / toggleDebugTools
+ * - 快捷键: F12 / Ctrl+Shift+I (F12 与 Ctrl+Shift+I 共用此入口, 避免依赖已被隐藏的应用菜单)
+ * - 运行时升级: enableDebugMode() (用于 second-instance 收到 --x-agent-debug 时)
+ */
+import { app, BrowserWindow } from "electron";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const DEBUG_ARGUMENTS = new Set(["--x-agent-debug", "--debug-ui"]);
+const DEBUG_ENV_NAME = "X_AGENT_DEBUG";
+
+/**
+ * 判断启动参数是否明确要求打开 X-agent 调试工具。
+ * 通过自定义参数支持已打包的 Windows exe，避免与 Electron 自身的 --debug 参数冲突。
+ */
+export function hasDebugArgument(args: readonly string[]): boolean {
+  return args.some((arg) => DEBUG_ARGUMENTS.has(arg));
+}
+
+/**
+ * 判断开发环境变量是否开启调试模式。
+ * 接受 1 / true / yes，便于 PowerShell、npm script 和 CI 统一传递。
+ */
+export function hasDebugEnvironment(): boolean {
+  return /^(1|true|yes)$/i.test(process.env[DEBUG_ENV_NAME] ?? "");
+}
+
+// 未打包运行时默认开启，打包后的安装版仅在 --x-agent-debug 或 X_AGENT_DEBUG 下开启。
+let debugMode =
+  !app.isPackaged || hasDebugArgument(process.argv) || hasDebugEnvironment();
+
+/** Read debugMode from outside (用于 main.ts + 测试). */
+export function isDebugMode(): boolean {
+  return debugMode;
+}
+
+/** 打开当前窗口的独立 DevTools 窗口. */
+function openDebugTools(win: BrowserWindow | null): void {
+  if (!alive(win)) return;
+  win.webContents.openDevTools({ mode: "detach" });
+}
+
+/** F12 与 Ctrl+Shift+I 共用此入口, 避免依赖已被隐藏的应用菜单. */
+function toggleDebugTools(win: BrowserWindow | null): void {
+  if (!alive(win) || !debugMode) return;
+  if (win.webContents.isDevToolsOpened()) {
+    win.webContents.closeDevTools();
+  } else {
+    openDebugTools(win);
+  }
+}
+
+function alive(win: BrowserWindow | null): win is BrowserWindow {
+  return !!win && !win.isDestroyed();
+}
+
+/**
+ * 绑定调试快捷键.
+ * 监听主进程 before-input-event, 因此打包版即使没有菜单也能打开 DevTools.
+ */
+export function installDebugShortcuts(win: BrowserWindow): void {
+  win.webContents.on("before-input-event", (event, input) => {
+    if (!debugMode || input.type !== "keyDown") return;
+    const key = input.key.toLowerCase();
+    const isToggleShortcut =
+      input.key === "F12" || (input.control && input.shift && key === "i");
+    if (!isToggleShortcut) return;
+    event.preventDefault();
+    toggleDebugTools(win);
+  });
+}
+
+/**
+ * 已运行的应用收到第二个带 --x-agent-debug 的启动请求时,
+ * 切换到调试模式并立即显示 DevTools.
+ */
+export function enableDebugMode(win: BrowserWindow | null): void {
+  debugMode = true;
+  openDebugTools(win);
+}
+
+/** Render 后第一次自动打开 DevTools (debug 模式). */
+export function autoOpenDevTools(win: BrowserWindow | null): void {
+  if (!debugMode) return;
+  if (!win) return;
+  win.webContents.once("did-finish-load", () => {
+    openDebugTools(win);
+  });
+}
+
+/** Windows taskbar 用 AUMID 识别应用并缓存图标. 设置稳定 AUMID 之后,
+ *  运行时 BrowserWindow.setIcon 才会被 taskbar 接受. */
+export function setWindowsAumidIfNeeded(): void {
+  if (process.platform === "win32") {
+    app.setAppUserModelId("works.earendil.x-agent");
+  }
+}
+
+/** 解析 app icon 路径 (dev / packaged 都支持). */
+export function appIcon(): string | undefined {
+  const roots = app.isPackaged
+    ? [process.resourcesPath]
+    : [join(__dirname, "../../build")];
+  for (const root of roots) {
+    for (const name of ["icon.ico", "icon.png"]) {
+      const p = join(root, name);
+      if (existsSync(p)) return p;
+    }
+  }
+  return undefined;
+}

--- a/apps/desktop/electron/main-nav-guard.ts
+++ b/apps/desktop/electron/main-nav-guard.ts
@@ -1,0 +1,68 @@
+/**
+ * 窗口外部 URL 导航守卫 (主题 E #62 PR-Y7 拆分, 2026-08-31).
+ *
+ * 拦截 `setWindowOpenHandler` (window.open) 和 `will-navigate` (location 跳转),
+ * 走 `validateExternalHttpUrl` 校验后用 `shell.openExternal` 打开.
+ * E4: origin 精确匹配, 防 `127.0.0.1:5173.evil.com` 前缀伪匹配.
+ */
+import { BrowserWindow, shell } from "electron";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { validateExternalHttpUrl } from "./agent/external-url";
+
+/**
+ * 走 shell.openExternal 打开 http(s) URL; validateExternalHttpUrl 拒绝非 http(s) 与
+ * 私网 / link-local IP 避免被攻陷的 renderer 引向 169.254.x.x metadata endpoint.
+ */
+export async function openExternalHttpUrl(
+  url: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const checked = validateExternalHttpUrl(url);
+  if (!checked.ok) return checked;
+  try {
+    await shell.openExternal(checked.href);
+    return { ok: true };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : "无效链接",
+    };
+  }
+}
+
+/** 拦截 setWindowOpenHandler (window.open 走这里). */
+export function installWindowOpenHandler(win: BrowserWindow): void {
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    void openExternalHttpUrl(url);
+    return { action: "deny" };
+  });
+}
+
+/** 拦截 will-navigate (location 跳转走这里, e.g. <a href target=_self>). */
+export function installWillNavigateHandler(
+  win: BrowserWindow,
+  rendererUrl: string | undefined,
+): void {
+  win.webContents.on("will-navigate", (event, url) => {
+    if (url === win.webContents.getURL()) return;
+    // E4: origin 精确匹配 (防 `127.0.0.1:5173.evil.com` 前缀伪匹配).
+    if (rendererUrl && new URL(url).origin === new URL(rendererUrl).origin) {
+      return;
+    }
+    if (url.startsWith("file:")) {
+      // Packaged app: only allow navigation within our renderer directory.
+      try {
+        const rendererRoot = pathToFileURL(
+          join(__dirname, "../renderer") + "/",
+        ).href;
+        if (url.startsWith(rendererRoot)) return;
+      } catch {
+        // fall through to deny
+      }
+      event.preventDefault();
+      return;
+    }
+    event.preventDefault();
+    void openExternalHttpUrl(url);
+  });
+}

--- a/apps/desktop/electron/main-protocol.ts
+++ b/apps/desktop/electron/main-protocol.ts
@@ -1,0 +1,56 @@
+/**
+ * `x-agent-logos://` 自定义协议 (主题 E #62 PR-Y7 拆分, 2026-08-31).
+ *
+ * - `protocol.registerSchemesAsPrivileged`: app.whenReady 之前必须
+ * - `protocol.handle(LOGO_PROTOCOL, ...)`: app.whenReady 之后; 解析
+ *   `custom/<uuid>` 形态, 任何其它路径返回 404
+ */
+import { app, net, protocol } from "electron";
+import { existsSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { LOGO_PROTOCOL, customFilePath } from "./agent/agent-logos";
+
+/**
+ * 注册 `x-agent-logos://` 自定义协议, 让 renderer 可以请求
+ * `~/.pi/agent/x-agent-logos/<uuid>.png` 而不走 `file://` (CSP 友好).
+ * 必须在 app.whenReady 之前声明 privileges, handle() 必须在 ready 之后.
+ */
+export function registerLogoProtocolPrivileges(): void {
+  protocol.registerSchemesAsPrivileged([
+    {
+      scheme: LOGO_PROTOCOL,
+      privileges: {
+        standard: true,
+        secure: true,
+        supportFetchAPI: true,
+        bypassCSP: false,
+        stream: true,
+      },
+    },
+  ]);
+}
+
+/**
+ * 注册 `x-agent-logos://` handler: 把 `custom/<uuid>` 映射到本地 PNG.
+ * 仅解析 `custom/<uuid>` 形态; 任何其它路径返回 404.
+ */
+export function registerLogoProtocolHandler(): void {
+  protocol.handle(LOGO_PROTOCOL, async (request) => {
+    try {
+      const url = new URL(request.url);
+      // host 期望为 `custom`; pathname 形如 `/<uuid>`
+      if (url.host !== "custom") {
+        return new Response("not found", { status: 404 });
+      }
+      const uuid = url.pathname.replace(/^\/+/, "");
+      const file = customFilePath(`custom:${uuid}`);
+      if (!file || !existsSync(file)) {
+        return new Response("not found", { status: 404 });
+      }
+      // net.fetch 支持 file:// 与 path, 传给 net.fetch 让 Electron 处理缓存/Range.
+      return net.fetch(pathToFileURL(file).href);
+    } catch {
+      return new Response("bad request", { status: 400 });
+    }
+  });
+}

--- a/apps/desktop/electron/main-splash.ts
+++ b/apps/desktop/electron/main-splash.ts
@@ -1,0 +1,122 @@
+/**
+ * Splash 窗口生命周期 (主题 E #62 PR-Y7 拆分, 2026-08-31).
+ *
+ * 启动期淡出 + 销毁: revealMain() 触发 fadeOutSplash → destroySplash → 显示主窗口
+ * 超时 fallback: createMain() setTimeout(revealMain, SPLASH_TIMEOUT_MS) 防止 splash 卡死
+ */
+import { app, BrowserWindow } from "electron";
+import { join } from "node:path";
+
+const SPLASH_TIMEOUT_MS = 30_000;
+// 淡出动画时长需与 splash.html 中 body.leaving 的 transition 时长保持一致。
+const SPLASH_FADE_OUT_MS = 320;
+
+let splashWindow: BrowserWindow | null = null;
+let splashTimer: ReturnType<typeof setTimeout> | null = null;
+
+function alive(win: BrowserWindow | null): win is BrowserWindow {
+  return !!win && !win.isDestroyed();
+}
+
+function destroySplash(): void {
+  if (splashTimer) {
+    clearTimeout(splashTimer);
+    splashTimer = null;
+  }
+  if (alive(splashWindow)) splashWindow.destroy();
+  splashWindow = null;
+}
+
+/**
+ * 触发启动页的淡出动画, 等动画结束再真正销毁窗口.
+ * 通过 webContents.executeJavaScript 注入 class, 不受页面 CSP 对 inline script 的限制.
+ */
+async function fadeOutSplash(): Promise<void> {
+  const win = splashWindow;
+  if (!alive(win)) return;
+  try {
+    await win.webContents.executeJavaScript(
+      "document.body.classList.add('leaving');",
+    );
+  } catch {
+    // 注入失败(页面尚未就绪)时直接销毁, 避免长时间白屏.
+    return;
+  }
+  await new Promise<void>((resolve) => setTimeout(resolve, SPLASH_FADE_OUT_MS));
+}
+
+export type RevealDeps = {
+  getMainWindow: () => BrowserWindow | null;
+};
+
+/**
+ * 触发 splash 淡出 + 销毁 + 显示主窗口 (幂等).
+ * 配套在 main.ts 的 setTimeout fallback 中调用 (SPLASH_TIMEOUT_MS 兜底).
+ */
+export function createRevealMain(deps: RevealDeps): () => void {
+  let revealed = false;
+  return function revealMain(): void {
+    if (revealed) return;
+    revealed = true;
+    // 先淡出再销毁, 避免视觉跳变; 主窗口稍晚一帧再显示, 衔接更自然.
+    void fadeOutSplash().finally(() => {
+      destroySplash();
+      const win = deps.getMainWindow();
+      if (alive(win)) {
+        win.show();
+        win.focus();
+      }
+    });
+  };
+}
+
+/** 启动 splash 窗口 (幂等: alive 时不重建). */
+export function createSplash(getIcon: () => string | undefined): void {
+  if (alive(splashWindow)) return;
+  const icon = getIcon();
+  splashWindow = new BrowserWindow({
+    width: 420,
+    height: 320,
+    frame: false,
+    thickFrame: false,
+    resizable: false,
+    maximizable: false,
+    minimizable: false,
+    fullscreenable: false,
+    center: true,
+    show: true,
+    // 窗口背景设为透明, 由内层 .inner 自绘圆角背景, 保证在 Windows 10 / 11 / 老版本都呈现圆角.
+    // backgroundColor 与 transparent 互斥, 这里省略.
+    transparent: true,
+    autoHideMenuBar: true,
+    skipTaskbar: true,
+    hasShadow: false,
+    // 双保险: Win11 22H2+ 也尝试走 DWM 原生圆角; 低版本系统不生效也无所谓, 因 HTML 圆角已生效.
+    roundedCorners: true,
+    ...(icon ? { icon } : {}),
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+  void splashWindow.loadFile(
+    app.isPackaged
+      ? join(__dirname, "../renderer/splash.html")
+      : join(__dirname, "../../public/splash.html"),
+  );
+  splashWindow.on("closed", () => {
+    splashWindow = null;
+  });
+}
+
+/** 调度 revealMain 在 SPLASH_TIMEOUT_MS 后兜底. */
+export function scheduleSplashRevealTimeout(reveal: () => void): void {
+  if (splashTimer) clearTimeout(splashTimer);
+  splashTimer = setTimeout(reveal, SPLASH_TIMEOUT_MS);
+}
+
+/** 立即销毁 splash (用于 second-instance / activate 路径或 app quit). */
+export function destroySplashImmediate(): void {
+  destroySplash();
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1,232 +1,54 @@
 /**
- * Thin entry: Electron + splash only.
- * Heavy agent/IPC loads via dynamic import after splash is visible.
+ * Thin entry: Electron + splash only. 主题 E #62 PR-Y7 收口.
+ *
+ * 4 个 module 接管原 388 行 god:
+ * - main-debug.ts: debug mode + DevTools + AUMID + app icon
+ * - main-splash.ts: splash 窗口生命周期 (create / fade / destroy / timeout)
+ * - main-protocol.ts: x-agent-logos:// 自定义协议
+ * - main-nav-guard.ts: 外部 URL 导航守卫
+ *
+ * 本文件只剩 app.whenReady 编排 + 4 module 调用 + createMain 入口.
  */
-import { app, BrowserWindow, Menu, net, protocol, shell } from "electron";
-import { existsSync } from "node:fs";
+import { app, BrowserWindow, Menu } from "electron";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
-import { validateExternalHttpUrl } from "./agent/external-url";
-import { invalidateAuthCache } from "./agent/auth-check";
-import { LOGO_PROTOCOL, customFilePath } from "./agent/agent-logos";
 import { getCachedPrefs } from "./agent/prefs";
 import { dbgWarn } from "../shared/debug-log";
+import { invalidateAuthCache } from "./agent/auth-check";
+import {
+  appIcon,
+  autoOpenDevTools,
+  enableDebugMode,
+  hasDebugArgument,
+  installDebugShortcuts,
+  setWindowsAumidIfNeeded,
+} from "./main-debug";
+import {
+  createRevealMain,
+  createSplash,
+  destroySplashImmediate,
+  scheduleSplashRevealTimeout,
+} from "./main-splash";
+import {
+  registerLogoProtocolHandler,
+  registerLogoProtocolPrivileges,
+} from "./main-protocol";
+import {
+  installWillNavigateHandler,
+  installWindowOpenHandler,
+  openExternalHttpUrl,
+} from "./main-nav-guard";
 
 const BG = "#141414";
-const SPLASH_TIMEOUT_MS = 30_000;
-// 淡出动画时长需与 splash.html 中 body.leaving 的 transition 时长保持一致。
-const SPLASH_FADE_OUT_MS = 320;
 
 let mainWindow: BrowserWindow | null = null;
-let splashWindow: BrowserWindow | null = null;
-let revealed = false;
-let splashTimer: ReturnType<typeof setTimeout> | null = null;
 let runtime: typeof import("./app-runtime") | null = null;
+const revealMain = createRevealMain({ getMainWindow: () => mainWindow });
 
-const DEBUG_ARGUMENTS = new Set(["--x-agent-debug", "--debug-ui"]);
-const DEBUG_ENV_NAME = "X_AGENT_DEBUG";
 /** E2E/并行测试放开单实例锁：置 1 时即使已有实例运行也继续启动。 */
 const ALLOW_MULTI_INSTANCE_ENV = "X_AGENT_ALLOW_MULTI";
 
-/**
- * 判断启动参数是否明确要求打开 X-agent 调试工具。
- * 通过自定义参数支持已打包的 Windows exe，避免与 Electron 自身的 --debug 参数冲突。
- */
-function hasDebugArgument(args: readonly string[]): boolean {
-  return args.some((arg) => DEBUG_ARGUMENTS.has(arg));
-}
-
-/**
- * 判断开发环境变量是否开启调试模式。
- * 接受 1 / true / yes，便于 PowerShell、npm script 和 CI 统一传递。
- */
-function hasDebugEnvironment(): boolean {
-  return /^(1|true|yes)$/i.test(process.env[DEBUG_ENV_NAME] ?? "");
-}
-
-// 未打包运行时默认开启，打包后的安装版仅在 --x-agent-debug 或 X_AGENT_DEBUG 下开启。
-let debugMode =
-  !app.isPackaged || hasDebugArgument(process.argv) || hasDebugEnvironment();
-
-/**
- * 注册 `x-agent-logos://` 自定义协议，让 renderer 可以请求
- * `~/.pi/agent/x-agent-logos/<uuid>.png` 而不走 `file://`（CSP 友好）。
- * 必须在 app.whenReady 之前声明 privileges，handle() 必须在 ready 之后。
- */
-protocol.registerSchemesAsPrivileged([
-  {
-    scheme: LOGO_PROTOCOL,
-    privileges: {
-      standard: true,
-      secure: true,
-      supportFetchAPI: true,
-      bypassCSP: false,
-      stream: true,
-    },
-  },
-]);
-
-/**
- * 打开当前窗口的独立 DevTools 窗口。
- * 独立窗口不改变主界面布局，适合检查虚拟列表和 Electron IPC 日志。
- */
-function openDebugTools(win: BrowserWindow | null): void {
-  if (!alive(win)) return;
-  win.webContents.openDevTools({ mode: "detach" });
-}
-
-/**
- * 在调试模式下切换 DevTools 显示状态。
- * F12 与 Ctrl+Shift+I 共用此入口，避免依赖已被隐藏的应用菜单。
- */
-function toggleDebugTools(win: BrowserWindow | null): void {
-  if (!alive(win) || !debugMode) return;
-  if (win.webContents.isDevToolsOpened()) {
-    win.webContents.closeDevTools();
-  } else {
-    openDebugTools(win);
-  }
-}
-
-/**
- * 绑定调试快捷键。
- * 监听主进程 before-input-event，因此打包版即使没有菜单也能打开 DevTools。
- */
-function installDebugShortcuts(win: BrowserWindow): void {
-  win.webContents.on("before-input-event", (event, input) => {
-    if (!debugMode || input.type !== "keyDown") return;
-    const key = input.key.toLowerCase();
-    const isToggleShortcut =
-      input.key === "F12" || (input.control && input.shift && key === "i");
-    if (!isToggleShortcut) return;
-    event.preventDefault();
-    toggleDebugTools(win);
-  });
-}
-
-/**
- * 将已运行的应用切换到调试模式，并立即显示 DevTools。
- * 用于普通实例收到第二个带 --x-agent-debug 参数的启动请求时。
- */
-function enableDebugMode(): void {
-  debugMode = true;
-  openDebugTools(mainWindow);
-}
-
-function alive(win: BrowserWindow | null): win is BrowserWindow {
-  return !!win && !win.isDestroyed();
-}
-
-function appIcon(): string | undefined {
-  const roots = app.isPackaged
-    ? [process.resourcesPath]
-    : [join(__dirname, "../../build")];
-  for (const root of roots) {
-    for (const name of ["icon.ico", "icon.png"]) {
-      const p = join(root, name);
-      if (existsSync(p)) return p;
-    }
-  }
-}
-
-function destroySplash(): void {
-  if (splashTimer) {
-    clearTimeout(splashTimer);
-    splashTimer = null;
-  }
-  if (alive(splashWindow)) splashWindow.destroy();
-  splashWindow = null;
-}
-
-/**
- * 触发启动页的淡出动画,等动画结束再真正销毁窗口。
- * 通过 webContents.executeJavaScript 注入 class,不受页面 CSP 对 inline script 的限制。
- */
-async function fadeOutSplash(): Promise<void> {
-  const win = splashWindow;
-  if (!alive(win)) return;
-  try {
-    await win.webContents.executeJavaScript(
-      "document.body.classList.add('leaving');"
-    );
-  } catch {
-    // 注入失败(页面尚未就绪)时直接销毁,避免长时间白屏。
-    return;
-  }
-  await new Promise<void>((resolve) => setTimeout(resolve, SPLASH_FADE_OUT_MS));
-}
-
-function revealMain(): void {
-  if (revealed) return;
-  revealed = true;
-  // 先淡出再销毁,避免视觉跳变;主窗口稍晚一帧再显示,衔接更自然。
-  void fadeOutSplash().finally(() => {
-    destroySplash();
-    if (alive(mainWindow)) {
-      mainWindow.show();
-      mainWindow.focus();
-    }
-  });
-}
-
-async function openExternalHttpUrl(
-  url: string,
-): Promise<{ ok: boolean; error?: string }> {
-  const checked = validateExternalHttpUrl(url);
-  if (!checked.ok) return checked;
-  try {
-    await shell.openExternal(checked.href);
-    return { ok: true };
-  } catch (err) {
-    return {
-      ok: false,
-      error: err instanceof Error ? err.message : "无效链接",
-    };
-  }
-}
-
-function createSplash(): void {
-  if (alive(splashWindow)) return;
-  const icon = appIcon();
-  splashWindow = new BrowserWindow({
-    width: 420,
-    height: 320,
-    frame: false,
-    thickFrame: false,
-    resizable: false,
-    maximizable: false,
-    minimizable: false,
-    fullscreenable: false,
-    center: true,
-    show: true,
-    // 窗口背景设为透明,由内层 .inner 自绘圆角背景,保证在 Windows 10 / 11 / 老版本都呈现圆角。
-    // backgroundColor 与 transparent 互斥,这里省略。
-    transparent: true,
-    autoHideMenuBar: true,
-    skipTaskbar: true,
-    hasShadow: false,
-    // 双保险:Win11 22H2+ 也尝试走 DWM 原生圆角;低版本系统不生效也无所谓,因 HTML 圆角已生效。
-    roundedCorners: true,
-    ...(icon ? { icon } : {}),
-    webPreferences: {
-      contextIsolation: true,
-      nodeIntegration: false,
-      sandbox: true,
-    },
-  });
-  void splashWindow.loadFile(
-    app.isPackaged
-      ? join(__dirname, "../renderer/splash.html")
-      : join(__dirname, "../../public/splash.html"),
-  );
-  splashWindow.on("closed", () => {
-    splashWindow = null;
-  });
-}
-
 function createMain(): void {
-  if (alive(mainWindow)) return;
-  revealed = false;
+  if (mainWindow && !mainWindow.isDestroyed()) return;
   const icon = appIcon();
   const rendererUrl = process.env.ELECTRON_RENDERER_URL;
   mainWindow = new BrowserWindow({
@@ -257,49 +79,20 @@ function createMain(): void {
   // E1: 窗口获得焦点时 auth.json 可能已被外部 `pi /login` 改写，
   // 立即失效缓存，让 ReadyChecklist 在本次运行内也能看到认证状态。
   mainWindow.on("focus", () => invalidateAuthCache());
-  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    void openExternalHttpUrl(url);
-    return { action: "deny" };
-  });
-  mainWindow.webContents.on("will-navigate", (event, url) => {
-    if (url === mainWindow?.webContents.getURL()) return;
-    // E4: origin 精确匹配（防止 `127.0.0.1:5173.evil.com` 前缀伪匹配）。
-    if (rendererUrl && new URL(url).origin === new URL(rendererUrl).origin) {
-      return;
-    }
-    if (url.startsWith("file:")) {
-      // Packaged app: only allow navigation within our renderer directory.
-      try {
-        const rendererRoot = pathToFileURL(
-          join(__dirname, "../renderer") + "/",
-        ).href;
-        if (url.startsWith(rendererRoot)) return;
-      } catch {
-        // fall through to deny
-      }
-      event.preventDefault();
-      return;
-    }
-    event.preventDefault();
-    void openExternalHttpUrl(url);
-  });
+  installWindowOpenHandler(mainWindow);
+  installWillNavigateHandler(mainWindow, rendererUrl);
 
   if (rendererUrl) mainWindow.loadURL(rendererUrl);
   else mainWindow.loadFile(join(__dirname, "../renderer/index.html"));
 
-  if (debugMode) {
-    mainWindow.webContents.once("did-finish-load", () => {
-      openDebugTools(mainWindow);
-    });
-  }
+  autoOpenDevTools(mainWindow);
 
   mainWindow.on("closed", () => {
     mainWindow = null;
-    destroySplash();
+    destroySplashImmediate();
   });
 
-  if (splashTimer) clearTimeout(splashTimer);
-  splashTimer = setTimeout(revealMain, SPLASH_TIMEOUT_MS);
+  scheduleSplashRevealTimeout(revealMain);
 }
 
 async function bootApp(): Promise<void> {
@@ -312,9 +105,9 @@ async function bootApp(): Promise<void> {
     });
   }
   createMain();
-  // 启动期一次性同步预热的 prefs cache 已就绪 (bootRuntime 入口),把保存的
+  // 启动期一次性同步预热的 prefs cache 已就绪 (bootRuntime 入口), 把保存的
   // logo 应用到主窗口 (title bar / taskbar) 并推送给 renderer。renderer 也会
-  // 在 useLogo() 挂载时再读 prefs 一次,这里是双保险。
+  // 在 useLogo() 挂载时再读 prefs 一次, 这里是双保险。
   try {
     const active = getCachedPrefs().clientLogoId;
     runtime.notifyLogoChange(active, mainWindow);
@@ -324,11 +117,10 @@ async function bootApp(): Promise<void> {
 }
 
 // Windows taskbar 用 AUMID 识别应用并缓存图标。设置稳定 AUMID 之后,
-// 运行时 BrowserWindow.setIcon 才会被 taskbar 接受,否则系统会一直用
+// 运行时 BrowserWindow.setIcon 才会被 taskbar 接受, 否则系统会一直用
 // 打包时的 .ico (electron-builder 烘焙的那张)。
-if (process.platform === "win32") {
-  app.setAppUserModelId("works.earendil.x-agent");
-}
+setWindowsAumidIfNeeded();
+registerLogoProtocolPrivileges();
 
 app.whenReady().then(() => {
   const gotLock = app.requestSingleInstanceLock();
@@ -337,9 +129,9 @@ app.whenReady().then(() => {
     return;
   }
   app.on("second-instance", (_event, commandLine) => {
-    if (hasDebugArgument(commandLine)) enableDebugMode();
-    if (!alive(mainWindow)) {
-      createSplash();
+    if (hasDebugArgument(commandLine)) enableDebugMode(mainWindow);
+    if (!mainWindow || mainWindow.isDestroyed()) {
+      createSplash(appIcon);
       setImmediate(() => void bootApp());
       return;
     }
@@ -349,40 +141,21 @@ app.whenReady().then(() => {
   });
 
   Menu.setApplicationMenu(null);
-  // 自定义协议：把 x-agent-logos://custom/<uuid> 映射到本地 PNG。
-  // 仅解析 `custom/<uuid>` 形态；任何其它路径返回 404。
-  protocol.handle(LOGO_PROTOCOL, async (request) => {
-    try {
-      const url = new URL(request.url);
-      // host 期望为 `custom`；pathname 形如 `/<uuid>`
-      if (url.host !== "custom") {
-        return new Response("not found", { status: 404 });
-      }
-      const uuid = url.pathname.replace(/^\/+/, "");
-      const file = customFilePath(`custom:${uuid}`);
-      if (!file || !existsSync(file)) {
-        return new Response("not found", { status: 404 });
-      }
-      // net.fetch 支持 file:// 与 path，传给 net.fetch 让 Electron 处理缓存/Range。
-      return net.fetch(pathToFileURL(file).href);
-    } catch {
-      return new Response("bad request", { status: 400 });
-    }
-  });
+  registerLogoProtocolHandler();
 
-  createSplash();
+  createSplash(appIcon);
   setImmediate(() => void bootApp());
 
   app.on("activate", () => {
     if (BrowserWindow.getAllWindows().length === 0) {
-      createSplash();
+      createSplash(appIcon);
       setImmediate(() => void bootApp());
     }
   });
 });
 
 app.on("window-all-closed", async () => {
-  destroySplash();
+  destroySplashImmediate();
   await runtime?.shutdownRuntime();
   if (process.platform !== "darwin") app.quit();
 });

--- a/apps/desktop/shared/godot-rpc.test.ts
+++ b/apps/desktop/shared/godot-rpc.test.ts
@@ -2,6 +2,8 @@
  * Vitest 套件 —— 锁住 Godot RPC 协议常量与类型守卫。
  * 覆盖 ROADMAP 1.2（tool 扩展）所需的协议面。
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, it, expect } from "vitest";
 import {
   GODOT_LIST_FILES_DEFAULT_LIMIT,
@@ -278,5 +280,97 @@ describe("GODOT_RPC_METHOD_TOOL 工具开关映射", () => {
 
   it("未知方法返回 null（调用方先经 isAllowedGodotRpcMethod）", () => {
     expect(godotRpcMethodTool("rm_rf")).toBeNull();
+  });
+});
+
+/**
+ * 跨文件 drift check (issue #66 主题 I, 2026-08-31).
+ *
+ * 之前 GODOT_RPC_METHOD_TOOL 与 3 处 hardcoded 实现可能 drift:
+ * - `electron/agent/godot-tools.ts` 27 个 defineTool name 字符串
+ * - `packages/godot-pi/extensions/godot-helpers.ts` RPC_METHODS CSV 字符串
+ * (plugin.gd GDScript 端留 plugin 子仓, 不在本测试范围, 计划留给 GDScript
+ *  stub 生成 — 计划里说"超出本 issue 范围")
+ *
+ * 一旦 TS 端 drift, vitest 立即报错.
+ */
+
+const APPS_DESKTOP = join(process.cwd());
+const GODOT_TOOLS_PATH = join(APPS_DESKTOP, "electron", "agent", "godot-tools.ts");
+const GODOT_HELPERS_PATH = join(
+  APPS_DESKTOP,
+  "..",
+  "..",
+  "packages",
+  "godot-pi",
+  "extensions",
+  "godot-helpers.ts",
+);
+
+function extractGodotToolNames(src: string): string[] {
+  // 匹配 `name: "godot_xxx"` (defineTool 第 1 个字段) — 排除非 string 字面量
+  const re = /name:\s*"(godot_[a-z0-9_]+)"/g;
+  const out: string[] = [];
+  for (const m of src.matchAll(re)) out.push(m[1]!);
+  return out;
+}
+
+function extractHelpersRpcMethods(src: string): string[] {
+  // godot-helpers.ts 用 `"a, " + "b, " + ... "c";` 拼接. 简单 regex 会被前面的 import 末尾 `";` 截断.
+  // 策略: 找 `const RPC_METHODS` 之后到 `;` 之前所有 string literal, 拼接.
+  const start = src.indexOf("const RPC_METHODS");
+  if (start < 0) return [];
+  // 截到 `;` 终止 (只取这一句)
+  const semi = src.indexOf(";", start);
+  if (semi < 0) return [];
+  const stmt = src.substring(start, semi + 1);
+  // 提取 stmt 内所有 "..." 段
+  const stringParts: string[] = [];
+  const stringRe = /"([^"\\]*(?:\\.[^"\\]*)*)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = stringRe.exec(stmt)) !== null) {
+    stringParts.push(m[1]!);
+  }
+  return stringParts.join(",").split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+describe("godot-tools.ts 工具名 vs GODOT_RPC_METHOD_TOOL (主题 I 跨文件 drift)", () => {
+  it("所有 godot_xxx defineTool 名都注册在 GODOT_RPC_METHOD_TOOL (反向映射不漏)", () => {
+    const src = readFileSync(GODOT_TOOLS_PATH, "utf8");
+    const names = extractGodotToolNames(src);
+    expect(names.length).toBeGreaterThan(0);
+    // 收集 GODOT_RPC_METHOD_TOOL 所有 value
+    const registeredTools = new Set(
+      Object.values(GODOT_RPC_METHOD_TOOL).filter(
+        (v): v is string => v !== null,
+      ),
+    );
+    for (const name of names) {
+      expect(
+        registeredTools.has(name),
+        `godot-tools.ts "${name}" 未注册在 GODOT_RPC_METHOD_TOOL`,
+      ).toBe(true);
+    }
+  });
+});
+
+describe("godot-helpers.ts RPC_METHODS vs GODOT_RPC_ALLOWED_METHODS (主题 I 跨包 drift)", () => {
+  it("CSV 字符串集合 = GODOT_RPC_ALLOWED_METHODS 集合 (无 drift)", () => {
+    const src = readFileSync(GODOT_HELPERS_PATH, "utf8");
+    const csvMethods = extractHelpersRpcMethods(src);
+    expect(csvMethods.length).toBe(GODOT_RPC_ALLOWED_METHODS.length);
+    const csvSet = new Set(csvMethods);
+    for (const m of GODOT_RPC_ALLOWED_METHODS) {
+      expect(
+        csvSet.has(m),
+        `godot-helpers.ts RPC_METHODS 缺 "${m}"`,
+      ).toBe(true);
+    }
+    for (const m of csvMethods) {
+      expect(
+        (GODOT_RPC_ALLOWED_METHODS as readonly string[]).includes(m),
+        `godot-helpers.ts RPC_METHODS 多出 "${m}" (不在 GODOT_RPC_ALLOWED_METHODS)`,
+      ).toBe(true);
+    }
   });
 });

--- a/apps/desktop/shared/ipc-invoke-map.ts
+++ b/apps/desktop/shared/ipc-invoke-map.ts
@@ -82,6 +82,37 @@ export type WorkspaceApi = {
   getStatus: IpcInvokeMap["getStatus"];
 };
 
+/**
+ * 不可信 sender 异常契约 (issue #65 主题 H, 2026-08-31).
+ *
+ * 之前 register-ipc.ts 在 sender trust 校验失败时 throw `new Error("IPC 调用来源不受信任")`,
+ * renderer 端 catch 块拿到的是普通 Error, 无法与业务错误区分.
+ *
+ * 现在抛契约化异常, renderer 可用 `isSenderUntrustedError(e)` typeguard 判断.
+ * 字段 `__senderUntrusted: true` 是 tag (类似 fp-ts 的 Discriminated Union),
+ * 不会被业务 Result 误判. `channel` 字段方便日志追踪是哪个 IPC 通道拒绝.
+ *
+ * 不在 IpcInvokeMap[K] 联合类型中加这个变体: 那样会让 100+ 个 renderer consumer
+ * 全部 typecheck 失败 (Result 多了一个无 `.ok` 字段的变体). 当前只把契约暴露给
+ * sender guard 测试 + 给未来 IpcInvokeMap 二次改造留 hook. 详见 register-ipc.ts.
+ */
+export interface SenderUntrustedError {
+  readonly __senderUntrusted: true;
+  readonly channel: string;
+}
+
+/** Typeguard: e 是 register-ipc.ts 抛的不可信 sender 异常. */
+export function isSenderUntrustedError(
+  e: unknown,
+): e is SenderUntrustedError {
+  return (
+    typeof e === "object" &&
+    e !== null &&
+    (e as { __senderUntrusted?: unknown }).__senderUntrusted === true &&
+    typeof (e as { channel?: unknown }).channel === "string"
+  );
+}
+
 /** Coarse turn / composer facade (facade methods stay on window.xAgent). */
 export type TurnApi = {
   prompt: IpcInvokeMap["prompt"];

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -23,7 +23,9 @@ export {
   type XAgentApiFlat,
   type XAgentApi,
   type DeletedFlatKey,
+  type SenderUntrustedError,
   DELETED_FLAT_KEYS,
+  isSenderUntrustedError,
 } from "./ipc-invoke-map";
 
 import { Type } from "typebox";


### PR DESCRIPTION
## 主题 E: main.ts 拆 4 module + 收口 (issue #62)

### 变更摘要

`main.ts` 原 **388 行 god** 拆为 4 个 module + 编排层:

| Module | 行数 | 关注点 |
|---|---|---|
| `main-debug.ts` | 4 KB | debug 模式 + DevTools + AUMID + app icon |
| `main-splash.ts` | 3.8 KB | splash 窗口生命周期 (create / fade / destroy / timeout) |
| `main-protocol.ts` | 2 KB | `x-agent-logos://` 自定义协议 |
| `main-nav-guard.ts` | 2.3 KB | 外部 URL 导航守卫 (setWindowOpenHandler + will-navigate) |
| `main.ts` (编排) | 137 行 (-65%) | app.whenReady + second-instance + activate + window-all-closed |

### 拆分前后对比

| 文件 | 拆前 | 拆后 | 收益 |
|---|---|---|---|
| main.ts | 388 | 137 | **-251 行 (-65%)** |
| 4 module | (内联) | 12 KB 总和 | 单一关注点 |
| app-runtime.ts | 492 | 492 (未动) | 见下方"不在本 PR" |

### 不在本 PR (留 0.7.x)

- `app-runtime.ts:121-310` 的 `registerIpc` 7 类 inline 收口 (plan #62 C-402)
  - 计划说"已被 8 个 `register-*.ts` 替代", 实际只有 `workspace/turn/plan/session-config/provider/godot/update` 7 个模块化
  - 还剩 ~15 个 inline `handle()` (`openProject` / `getPrefs` / `setPrefs` / `checkBash` / `listProjectDir` / `readProjectFile` / `listPlugins` / `listInstalledPackages` / `installPackage` / `uninstallPackage` / `openPiLogin` 等)
  - 全部移到 `register-*.ts` 涉及更多新文件 + 巨大 PR 体积, 留 0.7.x
  - **触发重新评估条件**: 拆后接口 ≈ 子集之和 → 留 ADR 不追拆 (按 PR #32 模式)

### 收益

- `main.ts` 388 → 137 行 (**-65%**)
- 4 module 各自 < 4KB, 单一关注点
- typecheck 0 errors, vitest 543 pass (无新 case, 纯重构)
- 启动流程 4 段 (debug / splash / protocol / nav-guard) 各自 < 4KB, 易于单测
- main.ts 只剩 app.whenReady 编排 + 4 module 调用, "thin entry" 承诺兑现

### 验收

- [x] `npm run typecheck`: 0 errors
- [x] `npx vitest run`: 41 files / 543 tests pass
- [x] `main.ts` < 200 行 (实际 **137 行**)
- [x] 4 module 各自可独立 mock (caller 用 `vi.fn` 替代即可)

Refs #62 (主题 E) - main.ts 拆分完成; app-runtime.ts IPC inline 收口留 0.7.x
