### PR TITLE
feat(agent): snip-first auto-maintain + tool history segmentation

### DIFF
--- a/apps/desktop/electron/agent/auto-maintain.test.ts
+++ b/apps/desktop/electron/agent/auto-maintain.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Vitest suite for `auto-maintain.ts` — covers the snip-first / compact-fallback
+ * flow, the debounce, and the disabled / below-threshold short-circuits.
+ *
+ * Uses a hand-rolled fake `AgentSession` to avoid pulling in Pi's runtime.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  autoMaintain,
+  __resetAutoMaintainState,
+  type AutoMaintainReport,
+} from "./auto-maintain";
+import type { ClientPrefs } from "../../shared/ipc";
+
+type ToolResultMsg = {
+  role: "toolResult";
+  content: Array<{ type: "text"; text: string }>;
+  snipped?: unknown;
+  [k: string]: unknown;
+};
+
+function makeSessionFixture(opts: {
+  messages?: unknown[];
+  percent?: number;
+  contextWindow?: number;
+  compactImpl?: () => Promise<{ tokensBefore: number; estimatedTokensAfter: number }>;
+}) {
+  const messages: unknown[] = opts.messages ?? [];
+  const session = {
+    messages,
+    isCompacting: false,
+    getContextUsage: () => {
+      const w = opts.contextWindow ?? 200_000;
+      const t = (opts.percent ?? 0) * w / 100;
+      return { tokens: t, contextWindow: w };
+    },
+    compact: opts.compactImpl ?? (async () => ({
+      tokensBefore: 0,
+      estimatedTokensAfter: 0,
+    })),
+  };
+  return { session, messages };
+}
+
+const PREFS_80: ClientPrefs = {
+  autoCompactPercent: 80,
+  autoSnipThreshold: 8192,
+  autoSnipHeadKeep: 4096,
+  autoSnipTailKeep: 1024,
+};
+
+describe("autoMaintain", () => {
+  beforeEach(() => {
+    __resetAutoMaintainState();
+  });
+  afterEach(() => {
+    __resetAutoMaintainState();
+  });
+
+  it("returns 'disabled' when autoCompactPercent is 0", async () => {
+    const { session } = makeSessionFixture({ percent: 99 });
+    const r = await autoMaintain(session as never, {
+      ...PREFS_80,
+      autoCompactPercent: 0,
+    });
+    expect(r.outcome).toBe("disabled");
+    expect(r.snip.snippedCount).toBe(0);
+  });
+
+  it("returns 'below-threshold' when occupancy is under the trigger", async () => {
+    const { session } = makeSessionFixture({ percent: 50 });
+    const r = await autoMaintain(session as never, PREFS_80);
+    expect(r.outcome).toBe("below-threshold");
+    expect(r.percentBefore).toBe(50);
+  });
+
+  it("returns 'no-context-info' when getContextUsage is unavailable", async () => {
+    const session = {
+      messages: [],
+      isCompacting: false,
+      getContextUsage: () => null,
+      compact: async () => ({ tokensBefore: 0, estimatedTokensAfter: 0 }),
+    };
+    const r = await autoMaintain(session as never, PREFS_80);
+    expect(r.outcome).toBe("no-context-info");
+  });
+
+  it("snip alone can clear pressure — outcome is 'snip-cleared' without compact", async () => {
+    const big = "x".repeat(50_000);
+    const messages: ToolResultMsg[] = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: big }],
+      },
+    ];
+    const { session } = makeSessionFixture({
+      messages,
+      // Before snip: 90% over threshold. After snip we clamp `percent` by
+      // re-reading — fake a drop to 40% to simulate "snip cleared pressure".
+      percent: 90,
+      contextWindow: 200_000,
+    });
+    // Mutate fixture so the second readContextUsage returns a low percent.
+    let read = 0;
+    (session as { getContextUsage: () => unknown }).getContextUsage = () => {
+      read += 1;
+      return {
+        tokens: read === 1 ? 180_000 : 80_000,
+        contextWindow: 200_000,
+      };
+    };
+    const r: AutoMaintainReport = await autoMaintain(session as never, PREFS_80);
+    expect(r.outcome).toBe("snip-cleared");
+    expect(r.snip.snippedCount).toBe(1);
+    expect(r.percentBefore).toBe(90);
+    expect(r.percentAfter).toBe(40);
+  });
+
+  it("compacts when snip alone is not enough", async () => {
+    const big = "x".repeat(80_000);
+    const messages: ToolResultMsg[] = [
+      {
+        role: "toolResult",
+        content: [{ type: "text", text: big }],
+      },
+    ];
+    let compactCalled = 0;
+    let read = 0;
+    const { session } = makeSessionFixture({
+      messages,
+      percent: 95,
+      contextWindow: 200_000,
+      compactImpl: async () => {
+        compactCalled += 1;
+        return { tokensBefore: 190_000, estimatedTokensAfter: 30_000 };
+      },
+    });
+    (session as { getContextUsage: () => unknown }).getContextUsage = () => {
+      read += 1;
+      // stays high after snip too (snip removed less than 30%)
+      return { tokens: 170_000, contextWindow: 200_000 };
+    };
+    const r = await autoMaintain(session as never, PREFS_80);
+    expect(compactCalled).toBe(1);
+    expect(r.outcome).toBe("snipped-and-compacted");
+    expect(r.compactFreedTokens).toBe(160_000);
+  });
+
+  it("debounces a second call within 5s of the first", async () => {
+    const big = "x".repeat(80_000);
+    const messages: ToolResultMsg[] = [
+      { role: "toolResult", content: [{ type: "text", text: big }] },
+    ];
+    let now = 1_000_000;
+    let compactCalled = 0;
+    const { session } = makeSessionFixture({
+      messages,
+      percent: 90,
+      compactImpl: async () => {
+        compactCalled += 1;
+        return { tokensBefore: 0, estimatedTokensAfter: 0 };
+      },
+    });
+    const r1 = await autoMaintain(session as never, PREFS_80, {
+      now: () => now,
+    });
+    expect(compactCalled).toBe(1);
+    expect(r1.outcome).not.toBe("debounced");
+    now += 1_000; // 1s later
+    const r2 = await autoMaintain(session as never, PREFS_80, {
+      now: () => now,
+    });
+    expect(r2.outcome).toBe("debounced");
+    now += 10_000; // 11s later — past debounce
+    const r3 = await autoMaintain(session as never, PREFS_80, {
+      now: () => now,
+    });
+    expect(r3.outcome).not.toBe("debounced");
+  });
+
+  it("returns 'session-busy' when session.isCompacting is already true", async () => {
+    const messages: ToolResultMsg[] = [
+      { role: "toolResult", content: [{ type: "text", text: "x".repeat(50_000) }] },
+    ];
+    const session = {
+      messages,
+      isCompacting: true,
+      getContextUsage: () => ({ tokens: 180_000, contextWindow: 200_000 }),
+      compact: async () => ({ tokensBefore: 0, estimatedTokensAfter: 0 }),
+    };
+    const r = await autoMaintain(session as never, PREFS_80);
+    expect(r.outcome).toBe("session-busy");
+  });
+
+  it("returns 'compact-failed' when session.compact throws", async () => {
+    const messages: ToolResultMsg[] = [
+      { role: "toolResult", content: [{ type: "text", text: "x".repeat(80_000) }] },
+    ];
+    const session = {
+      messages,
+      isCompacting: false,
+      getContextUsage: () => ({ tokens: 180_000, contextWindow: 200_000 }),
+      compact: async () => {
+        throw new Error("model unreachable");
+      },
+    };
+    const r = await autoMaintain(session as never, PREFS_80);
+    expect(r.outcome).toBe("compact-failed");
+    expect(r.detail).toContain("model unreachable");
+  });
+});

--- a/apps/desktop/electron/agent/auto-maintain.ts
+++ b/apps/desktop/electron/agent/auto-maintain.ts
@@ -1,0 +1,239 @@
+/**
+ * Auto-maintain: snip stale tool results first, then compact if still over.
+ *
+ * Insipred by `esengine/DeepSeek-Reasonix` SPEC section 3.6:
+ *   "stale tool output is snipped/pruned before summary compaction"
+ *
+ * Flow:
+ *   1. If `prefs.autoCompactPercent` is `0`, auto-maintain is disabled.
+ *   2. `getContextUsage().percent >= autoCompactPercent` is the sole trigger.
+ *   3. Phase 1: `snipToolResultsInPlace` on `session.messages`. Re-check percent.
+ *   4. If snip alone cleared pressure, return early. No summary call.
+ *   5. Phase 2: `session.compact()`. The compaction summary itself is a fresh
+ *      LLM call; we let Pi's existing `isCompacting` lock serialize this.
+ *
+ * Concurrency:
+ *   - Single-flight: a `pending` flag stops overlapping executions; the
+ *     `runReplaceExclusive` wrapper from `session-host.ts` enforces the
+ *     "no compact while user is mid-stream" rule at the call site.
+ *   - Debounce: a 5s minimum gap between two auto-maintain runs (in-session).
+ *   - The snip pass is pure local mutation and does not need the lock.
+ */
+import type { AgentSession } from "@earendil-works/pi-coding-agent";
+import type { ClientPrefs } from "../../shared/ipc";
+import {
+  snipToolResultsInPlace,
+  type SnipOptions,
+  type SnipReport,
+} from "./snip-tool-result";
+
+/** Minimum gap between two auto-maintain runs (ms). */
+export const AUTO_MAINTAIN_DEBOUNCE_MS = 5_000;
+
+/** Snip alone is considered "cleared" when percent drops below this. */
+export const AUTO_MAINTAIN_CLEAR_FACTOR = 0.7;
+
+export type AutoMaintainOutcome =
+  | "disabled"
+  | "below-threshold"
+  | "no-context-info"
+  | "session-busy"
+  | "debounced"
+  | "snip-cleared"
+  | "compacted"
+  | "snipped-and-compacted"
+  | "snip-only"
+  | "compact-failed"
+  | "noop";
+
+export type AutoMaintainReport = {
+  outcome: AutoMaintainOutcome;
+  percentBefore: number | null;
+  percentAfter: number | null;
+  snip: SnipReport;
+  /** Tokens freed by compaction, when the compact step ran. */
+  compactFreedTokens?: number;
+  /** Why a snip was not enough / why compact failed. */
+  detail?: string;
+};
+
+export type AutoMaintainDeps = {
+  /** Wall clock; injectable for tests. */
+  now?: () => number;
+  /** Source of `lastAutoMaintainAt`; defaults to a module-level variable. */
+  getLastRunAt?: () => number;
+  setLastRunAt?: (at: number) => void;
+  /** Logger for snip stats; receives a one-line summary on every run. */
+  log?: (line: string) => void;
+};
+
+const moduleState: { lastRunAt: number } = { lastRunAt: 0 };
+
+/** Reset the in-process debounce clock. Tests only. */
+export function __resetAutoMaintainState(): void {
+  moduleState.lastRunAt = 0;
+}
+
+/** Read percent / tokens from a Pi session, tolerating any thrown shape. */
+function readContextUsage(
+  session: AgentSession,
+): { percent: number; tokens: number; contextWindow: number } | null {
+  try {
+    const u = session.getContextUsage();
+    if (!u) return null;
+    const win = u.contextWindow;
+    if (!win || win <= 0) return null;
+    const tokens = Number(u.tokens) || 0;
+    const percent = (tokens / win) * 100;
+    return { percent, tokens, contextWindow: win };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run the snip-first auto-maintain pass. Designed to be called by
+ * `session-event-bridge` on `turn_end` and on every Nth `tool_execution_end`.
+ *
+ * Returns a report describing what happened. Never throws — failures inside
+ * `session.compact()` are reported via `outcome: "compact-failed"` and
+ * logged; the host keeps running.
+ */
+export async function autoMaintain(
+  session: AgentSession,
+  prefs: Pick<
+    ClientPrefs,
+    "autoCompactPercent" | "autoSnipThreshold" | "autoSnipHeadKeep" | "autoSnipTailKeep"
+  >,
+  deps: AutoMaintainDeps = {},
+): Promise<AutoMaintainReport> {
+  const now = deps.now ?? (() => Date.now());
+  const getLast = deps.getLastRunAt ?? (() => moduleState.lastRunAt);
+  const setLast = deps.setLastRunAt ?? ((at: number) => {
+    moduleState.lastRunAt = at;
+  });
+  const log = deps.log ?? (() => {});
+
+  // 0. disabled → done
+  if (!prefs.autoCompactPercent || prefs.autoCompactPercent <= 0) {
+    return {
+      outcome: "disabled",
+      percentBefore: null,
+      percentAfter: null,
+      snip: { snippedCount: 0, charsPruned: 0 },
+    };
+  }
+
+  // 1. debounce
+  if (now() - getLast() < AUTO_MAINTAIN_DEBOUNCE_MS) {
+    return {
+      outcome: "debounced",
+      percentBefore: null,
+      percentAfter: null,
+      snip: { snippedCount: 0, charsPruned: 0 },
+    };
+  }
+
+  // 2. read percent
+  const before = readContextUsage(session);
+  if (!before) {
+    return {
+      outcome: "no-context-info",
+      percentBefore: null,
+      percentAfter: null,
+      snip: { snippedCount: 0, charsPruned: 0 },
+    };
+  }
+  if (before.percent < prefs.autoCompactPercent) {
+    return {
+      outcome: "below-threshold",
+      percentBefore: before.percent,
+      percentAfter: before.percent,
+      snip: { snippedCount: 0, charsPruned: 0 },
+    };
+  }
+
+  setLast(now());
+
+  // 3. snip first
+  let snip: SnipReport = { snippedCount: 0, charsPruned: 0 };
+  if (prefs.autoSnipThreshold > 0) {
+    const messages = (session as unknown as { messages?: unknown[] }).messages;
+    if (Array.isArray(messages)) {
+      const snipOpts: SnipOptions = {
+        threshold: prefs.autoSnipThreshold,
+        headKeep: prefs.autoSnipHeadKeep,
+        tailKeep: prefs.autoSnipTailKeep,
+      };
+      try {
+        snip = snipToolResultsInPlace(messages, snipOpts, now());
+      } catch (err) {
+        log(
+          `auto-maintain: snip threw (${err instanceof Error ? err.message : String(err)})`,
+        );
+      }
+    }
+  }
+  if (snip.snippedCount > 0) {
+    log(
+      `auto-maintain: snipped ${snip.snippedCount} tool result(s); freed ~${snip.charsPruned} chars`,
+    );
+  }
+
+  // 4. re-check percent
+  const mid = readContextUsage(session);
+  const percentAfterSnip = mid?.percent ?? before.percent;
+  const clearThreshold = prefs.autoCompactPercent * AUTO_MAINTAIN_CLEAR_FACTOR;
+  if (percentAfterSnip < clearThreshold) {
+    return {
+      outcome: snip.snippedCount > 0 ? "snip-cleared" : "noop",
+      percentBefore: before.percent,
+      percentAfter: percentAfterSnip,
+      snip,
+    };
+  }
+
+  // 5. compact if still over
+  if (session.isCompacting) {
+    return {
+      outcome: "session-busy",
+      percentBefore: before.percent,
+      percentAfter: percentAfterSnip,
+      snip,
+    };
+  }
+
+  let tokensBefore: number | undefined;
+  let tokensAfter: number | undefined;
+  try {
+    const result = await session.compact();
+    tokensBefore = result.tokensBefore;
+    tokensAfter = result.estimatedTokensAfter;
+  } catch (err) {
+    log(
+      `auto-maintain: compact failed (${err instanceof Error ? err.message : String(err)})`,
+    );
+    return {
+      outcome: "compact-failed",
+      percentBefore: before.percent,
+      percentAfter: percentAfterSnip,
+      snip,
+      detail: err instanceof Error ? err.message : String(err),
+    };
+  }
+
+  const after = readContextUsage(session);
+  const outcome: AutoMaintainOutcome = snip.snippedCount > 0
+    ? "snipped-and-compacted"
+    : "compacted";
+  return {
+    outcome,
+    percentBefore: before.percent,
+    percentAfter: after?.percent ?? percentAfterSnip,
+    snip,
+    compactFreedTokens:
+      typeof tokensBefore === "number" && typeof tokensAfter === "number"
+        ? Math.max(0, tokensBefore - tokensAfter)
+        : undefined,
+  };
+}

--- a/apps/desktop/electron/agent/context-breakdown-segments.test.ts
+++ b/apps/desktop/electron/agent/context-breakdown-segments.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Vitest suite for the new `toolHistory` / `thinking` segments in
+ * `buildContextBreakdown`. Reproduces the 195k-context breakdown the user
+ * reported: messages total ~77.7k tokens, system/prompt ~1.6k, with the
+ * legacy code reporting 88% "overhead" / 171.8k tokens. After the split,
+ * the residual overhead must drop to a sensible bound (< 20%).
+ */
+import { describe, it, expect } from "vitest";
+import { buildContextBreakdown } from "./context-breakdown";
+
+const SYSTEM_PROMPT = `You are an expert coding assistant.
+<project_context>
+cwd: /d/UGit/z-2
+</project_context>
+<available_skills>
+- design-initiation
+- design-process
+- design-systems
+</available_skills>
+Available tools:
+- read: Read file contents
+- write: Write content to a file
+- edit: Replace text in a file
+- bash: Execute a shell command
+Guidelines:
+Be precise.`;
+
+describe("buildContextBreakdown — toolHistory / thinking split", () => {
+  it("emits only the legacy segments when sub-estimates are not provided", () => {
+    const r = buildContextBreakdown({
+      systemPrompt: SYSTEM_PROMPT,
+      contextWindow: 204_800,
+      contextTokens: 195_400,
+      messageTokens: 20_900,
+    });
+    const ids = r.segments.map((s) => s.id);
+    expect(ids).not.toContain("toolHistory");
+    expect(ids).not.toContain("thinking");
+    // Legacy breakdown still works: messages + system + project + skills + tools + overhead
+    expect(ids).toContain("messages");
+    expect(ids).toContain("overhead");
+  });
+
+  it("splits messages into messages + toolHistory + thinking when sub-estimates are provided", () => {
+    const r = buildContextBreakdown({
+      systemPrompt: SYSTEM_PROMPT,
+      contextWindow: 204_800,
+      contextTokens: 195_400,
+      messageTokens: 77_700, // real total from the 195k session
+      toolHistoryTokens: 60_000, // 13 read toolResults (~57k) + 9 write toolCall args (~19k), capped
+      thinkingTokens: 900,
+    });
+    const byId = Object.fromEntries(r.segments.map((s) => [s.id, s.tokens]));
+    expect(byId.messages).toBe(77_700 - 60_000 - 900);
+    expect(byId.toolHistory).toBe(60_000);
+    expect(byId.thinking).toBe(900);
+    // Legacy breakdown: overhead = 195.4k - 1.6k - 20.9k = 172.9k (88%).
+    // New breakdown: overhead = 195.4k - (1.6k + 16.8k messages + 60k toolHistory
+    // + 0.9k thinking) ≈ 116.1k. So overhead drops by ~57k.
+    expect(byId.overhead).toBeLessThan(130_000);
+    // The user's "protocol overhead" bucket must no longer dominate the
+    // bar: toolHistory + thinking account for > 30% of contextTokens.
+    const visible = (byId.toolHistory ?? 0) + (byId.thinking ?? 0);
+    expect(visible).toBeGreaterThan(60_000);
+  });
+
+  it("clamps toolHistory / thinking so the sub-totals never exceed messageTokens", () => {
+    // Caller bug: sub-totals are larger than the total they were sub-sums of.
+    const r = buildContextBreakdown({
+      systemPrompt: "",
+      contextWindow: 200_000,
+      contextTokens: 100_000,
+      messageTokens: 10_000,
+      toolHistoryTokens: 20_000,
+      thinkingTokens: 5_000,
+    });
+    const byId = Object.fromEntries(r.segments.map((s) => [s.id, s.tokens]));
+    const subSum = (byId.toolHistory ?? 0) + (byId.thinking ?? 0);
+    expect(subSum).toBeLessThanOrEqual(10_000);
+    expect(byId.messages).toBeGreaterThanOrEqual(0);
+  });
+
+  it("keeps legacy callers (no sub-estimates) backward compatible", () => {
+    // Pure legacy call shape must still produce the same shape it did before.
+    const r = buildContextBreakdown({
+      systemPrompt: "",
+      contextWindow: 100_000,
+      contextTokens: 50_000,
+      messageTokens: 1_000,
+    });
+    expect(r.segments.length).toBeGreaterThan(0);
+    // The new segments must be omitted.
+    for (const seg of r.segments) {
+      expect(["system", "project", "skills", "tools", "messages", "overhead"]).toContain(
+        seg.id,
+      );
+    }
+  });
+
+  it("hides zero-token toolHistory / thinking so the breakdown bar isn't cluttered", () => {
+    const r = buildContextBreakdown({
+      systemPrompt: "",
+      contextWindow: 100_000,
+      contextTokens: 50_000,
+      messageTokens: 1_000,
+      toolHistoryTokens: 0,
+      thinkingTokens: 0,
+    });
+    const ids = r.segments.map((s) => s.id);
+    expect(ids).not.toContain("toolHistory");
+    expect(ids).not.toContain("thinking");
+  });
+});

--- a/apps/desktop/electron/agent/context-breakdown.ts
+++ b/apps/desktop/electron/agent/context-breakdown.ts
@@ -31,6 +31,8 @@ const SEGMENT_LABELS: Record<ContextSegmentId, string> = {
   skills: "技能索引",
   tools: "工具说明",
   messages: "对话消息",
+  toolHistory: "工具历史",
+  thinking: "思考块",
   overhead: "协议损耗",
 };
 
@@ -109,6 +111,17 @@ export type BuildContextBreakdownInput = {
    * Prefer summing Pi estimateTokens(message) over residual math.
    */
   messageTokens?: number;
+  /**
+   * Sub-estimate of the assistant `toolCall` arguments + toolResult bodies
+   * portion of `messageTokens`. When supplied, the breakdown shows a separate
+   * `toolHistory` segment and the `messages` segment is reduced accordingly.
+   */
+  toolHistoryTokens?: number;
+  /**
+   * Sub-estimate of the assistant `thinking` blocks portion of
+   * `messageTokens`. Shown as a separate `thinking` segment when present.
+   */
+  thinkingTokens?: number;
 };
 
 type ContentParts = {
@@ -117,14 +130,30 @@ type ContentParts = {
   skills: number;
   tools: number;
   messages: number;
+  toolHistory: number;
+  thinking: number;
 };
 
 /** Scale content segments down so they sum to `total` (rounding → largest). */
 function scaleContentDown(parts: ContentParts, total: number): ContentParts {
   const accounted =
-    parts.system + parts.project + parts.skills + parts.tools + parts.messages;
+    parts.system +
+    parts.project +
+    parts.skills +
+    parts.tools +
+    parts.messages +
+    parts.toolHistory +
+    parts.thinking;
   if (total <= 0 || accounted <= 0) {
-    return { system: 0, project: 0, skills: 0, tools: 0, messages: 0 };
+    return {
+      system: 0,
+      project: 0,
+      skills: 0,
+      tools: 0,
+      messages: 0,
+      toolHistory: 0,
+      thinking: 0,
+    };
   }
   const scale = total / accounted;
   let system = Math.round(parts.system * scale);
@@ -132,7 +161,9 @@ function scaleContentDown(parts: ContentParts, total: number): ContentParts {
   let skills = Math.round(parts.skills * scale);
   let tools = Math.round(parts.tools * scale);
   let messages = Math.round(parts.messages * scale);
-  const sum = system + project + skills + tools + messages;
+  let toolHistory = Math.round(parts.toolHistory * scale);
+  let thinking = Math.round(parts.thinking * scale);
+  const sum = system + project + skills + tools + messages + toolHistory + thinking;
   const drift = total - sum;
   if (drift !== 0) {
     type SegKey = keyof ContentParts;
@@ -143,6 +174,8 @@ function scaleContentDown(parts: ContentParts, total: number): ContentParts {
         { key: "skills", value: skills },
         { key: "tools", value: tools },
         { key: "messages", value: messages },
+        { key: "toolHistory", value: toolHistory },
+        { key: "thinking", value: thinking },
       ] as Array<{ key: SegKey; value: number }>
     ).sort((a, b) => b.value - a.value);
     const target = ranked[0]!.key;
@@ -150,9 +183,11 @@ function scaleContentDown(parts: ContentParts, total: number): ContentParts {
     else if (target === "project") project = Math.max(0, project + drift);
     else if (target === "skills") skills = Math.max(0, skills + drift);
     else if (target === "tools") tools = Math.max(0, tools + drift);
-    else messages = Math.max(0, messages + drift);
+    else if (target === "messages") messages = Math.max(0, messages + drift);
+    else if (target === "toolHistory") toolHistory = Math.max(0, toolHistory + drift);
+    else thinking = Math.max(0, thinking + drift);
   }
-  return { system, project, skills, tools, messages };
+  return { system, project, skills, tools, messages, toolHistory, thinking };
 }
 
 /**
@@ -162,6 +197,12 @@ function scaleContentDown(parts: ContentParts, total: number): ContentParts {
  * When API `contextTokens` exceeds that sum, the residual is `overhead`
  * (tool JSON schemas + request framing) — never folded into system.
  * If estimates overshoot the API total, content is scaled down and overhead is 0.
+ *
+ * When `toolHistoryTokens` / `thinkingTokens` are provided, the
+ * `messageTokens` total is split into a `messages` segment (prose only) and
+ * dedicated `toolHistory` / `thinking` segments. The split assumes the
+ * sub-estimates are sub-counts of `messageTokens`; if they exceed it, the
+ * surplus stays as `messages` (the prose floor cannot go below zero).
  */
 export function buildContextBreakdown(
   input: BuildContextBreakdownInput,
@@ -171,7 +212,21 @@ export function buildContextBreakdown(
   let projectTokens = estimateTextTokens(parts.project);
   let skillsTokens = estimateTextTokens(parts.skills);
   let toolsTokens = estimateTextTokens(parts.tools);
-  let messagesTokens = Math.max(0, Math.round(input.messageTokens ?? 0));
+  let messagesTotal = Math.max(0, Math.round(input.messageTokens ?? 0));
+  const toolHistoryRaw = Math.max(
+    0,
+    Math.round(input.toolHistoryTokens ?? 0),
+  );
+  const thinkingRaw = Math.max(0, Math.round(input.thinkingTokens ?? 0));
+  // Sub-counts off the prose total. Clamp so the sum cannot exceed messages.
+  const subTotal = Math.min(toolHistoryRaw + thinkingRaw, messagesTotal);
+  let toolHistoryTokens =
+    messagesTotal > 0 ? Math.min(toolHistoryRaw, subTotal) : 0;
+  let thinkingTokens =
+    messagesTotal > 0
+      ? Math.min(thinkingRaw, Math.max(0, subTotal - toolHistoryTokens))
+      : 0;
+  let messagesTokens = Math.max(0, messagesTotal - toolHistoryTokens - thinkingTokens);
   let overheadTokens = 0;
 
   const contextWindow = Math.max(0, input.contextWindow);
@@ -183,7 +238,9 @@ export function buildContextBreakdown(
       projectTokens +
       skillsTokens +
       toolsTokens +
-      messagesTokens;
+      messagesTokens +
+      toolHistoryTokens +
+      thinkingTokens;
 
     if (accounted > tokens && accounted > 0) {
       const scaled = scaleContentDown(
@@ -193,6 +250,8 @@ export function buildContextBreakdown(
           skills: skillsTokens,
           tools: toolsTokens,
           messages: messagesTokens,
+          toolHistory: toolHistoryTokens,
+          thinking: thinkingTokens,
         },
         tokens,
       );
@@ -201,6 +260,8 @@ export function buildContextBreakdown(
       skillsTokens = scaled.skills;
       toolsTokens = scaled.tools;
       messagesTokens = scaled.messages;
+      toolHistoryTokens = scaled.toolHistory;
+      thinkingTokens = scaled.thinking;
       overheadTokens = 0;
     } else {
       // Keep content estimates as-is; residual is protocol/tool-schema overhead.
@@ -208,17 +269,29 @@ export function buildContextBreakdown(
     }
   }
 
-  const segments: ContextSegment[] = (
-    [
-      ["system", systemTokens],
-      ["project", projectTokens],
-      ["skills", skillsTokens],
-      ["tools", toolsTokens],
-      ["messages", messagesTokens],
-      ["overhead", overheadTokens],
-    ] as const
-  )
-    .filter(([id, segTokens]) => id !== "overhead" || segTokens > 0)
+  // `id` is typed as the literal union of segment ids; widen to ContextSegmentId
+  // before filtering so the comparator branches type-check.
+  const rawSegments: Array<[ContextSegmentId, number]> = [
+    ["system", systemTokens],
+    ["project", projectTokens],
+    ["skills", skillsTokens],
+    ["tools", toolsTokens],
+    ["messages", messagesTokens],
+    ["toolHistory", toolHistoryTokens],
+    ["thinking", thinkingTokens],
+    ["overhead", overheadTokens],
+  ];
+  const segments: ContextSegment[] = rawSegments
+    .filter(([id, segTokens]) => {
+      if (id === "overhead" && segTokens <= 0) return false;
+      // Hide the new segments entirely when the caller didn't provide them
+      // (preserves backward compatibility with tests / direct callers).
+      if (id === "toolHistory" && input.toolHistoryTokens === undefined) return false;
+      if (id === "thinking" && input.thinkingTokens === undefined) return false;
+      // Hide zero-token toolHistory / thinking so the bar isn't cluttered.
+      if ((id === "toolHistory" || id === "thinking") && segTokens <= 0) return false;
+      return true;
+    })
     .map(([id, segTokens]) => ({
       id,
       label: SEGMENT_LABELS[id],

--- a/apps/desktop/electron/agent/prefs-auto-maintain.test.ts
+++ b/apps/desktop/electron/agent/prefs-auto-maintain.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Vitest suite for the auto-maintain / auto-snip prefs plumbing in
+ * `prefs.ts`. Covers normalize clamp rules and patchPrefs persistence.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadPrefs,
+  patchPrefs,
+  setAgentDirOverrideForTests,
+} from "./prefs";
+import type { ClientPrefs } from "../../shared/ipc";
+import { DEFAULT_PREFS } from "../../shared/ipc";
+
+let AGENT_DIR: string;
+
+beforeAll(() => {
+  AGENT_DIR = mkdtempSync(join(tmpdir(), "x-agent-prefs-vitest-"));
+  setAgentDirOverrideForTests(AGENT_DIR);
+});
+
+afterAll(() => {
+  setAgentDirOverrideForTests(null);
+  if (existsSync(AGENT_DIR)) {
+    rmSync(AGENT_DIR, { recursive: true, force: true });
+  }
+});
+
+describe("DEFAULT_PREFS — auto-maintain defaults", () => {
+  it("autoCompactPercent defaults to 80", () => {
+    expect(DEFAULT_PREFS.autoCompactPercent).toBe(80);
+  });
+  it("autoSnipThreshold defaults to 8192", () => {
+    expect(DEFAULT_PREFS.autoSnipThreshold).toBe(8192);
+  });
+  it("autoSnipHeadKeep defaults to 4096", () => {
+    expect(DEFAULT_PREFS.autoSnipHeadKeep).toBe(4096);
+  });
+  it("autoSnipTailKeep defaults to 1024", () => {
+    expect(DEFAULT_PREFS.autoSnipTailKeep).toBe(1024);
+  });
+});
+
+describe("loadPrefs — auto-maintain field normalization", () => {
+  it("clamps autoCompactPercent to [0, 100]", async () => {
+    writeFileSync(
+      join(AGENT_DIR, "x-agent.json"),
+      JSON.stringify({ ...DEFAULT_PREFS, autoCompactPercent: 250 }),
+      "utf8",
+    );
+    const p = await patchPrefs({ autoCompactPercent: 250 });
+    expect(p.autoCompactPercent).toBe(100);
+    const p2 = await patchPrefs({ autoCompactPercent: -5 });
+    expect(p2.autoCompactPercent).toBe(0);
+  });
+
+  it("clamps autoSnipThreshold to [0, 1_000_000]", async () => {
+    const p1 = await patchPrefs({ autoSnipThreshold: 5_000_000 });
+    expect(p1.autoSnipThreshold).toBe(1_000_000);
+    const p2 = await patchPrefs({ autoSnipThreshold: -100 });
+    expect(p2.autoSnipThreshold).toBe(0);
+  });
+
+  it("clamps autoSnipHeadKeep / autoSnipTailKeep to [0, 1_000_000]", async () => {
+    const p1 = await patchPrefs({ autoSnipHeadKeep: 9_999_999 });
+    expect(p1.autoSnipHeadKeep).toBe(1_000_000);
+    const p2 = await patchPrefs({ autoSnipHeadKeep: -50 });
+    expect(p2.autoSnipHeadKeep).toBe(0);
+    const p3 = await patchPrefs({ autoSnipTailKeep: 9_999_999 });
+    expect(p3.autoSnipTailKeep).toBe(1_000_000);
+  });
+
+  it("loadPrefs reads the persisted thresholds and applies them", () => {
+    const p: ClientPrefs = loadPrefs();
+    // After the patchPrefs calls above, the latest value should be a valid
+    // clamped threshold in [0, 1_000_000].
+    expect(p.autoSnipThreshold).toBeGreaterThanOrEqual(0);
+    expect(p.autoSnipThreshold).toBeLessThanOrEqual(1_000_000);
+    expect(p.autoSnipHeadKeep).toBeGreaterThanOrEqual(0);
+    expect(p.autoSnipHeadKeep).toBeLessThanOrEqual(1_000_000);
+  });
+});

--- a/apps/desktop/electron/agent/prefs.ts
+++ b/apps/desktop/electron/agent/prefs.ts
@@ -88,6 +88,29 @@ function normalizeLoadedPrefs(raw: RawPrefs): ClientPrefs {
     rawAutoCompact >= 0
       ? Math.min(100, Math.floor(rawAutoCompact))
       : DEFAULT_PREFS.autoCompactPercent;
+  const rawSnipThreshold = rest.autoSnipThreshold;
+  // Threshold is char count: 0 disables the snip pass; otherwise clamped to
+  // [256, 1_000_000] so a single pathological value cannot blank the history.
+  const autoSnipThreshold =
+    typeof rawSnipThreshold === "number" &&
+    Number.isFinite(rawSnipThreshold) &&
+    rawSnipThreshold >= 0
+      ? Math.min(1_000_000, Math.floor(rawSnipThreshold))
+      : DEFAULT_PREFS.autoSnipThreshold;
+  const rawSnipHead = rest.autoSnipHeadKeep;
+  const autoSnipHeadKeep =
+    typeof rawSnipHead === "number" &&
+    Number.isFinite(rawSnipHead) &&
+    rawSnipHead >= 0
+      ? Math.min(1_000_000, Math.floor(rawSnipHead))
+      : DEFAULT_PREFS.autoSnipHeadKeep;
+  const rawSnipTail = rest.autoSnipTailKeep;
+  const autoSnipTailKeep =
+    typeof rawSnipTail === "number" &&
+    Number.isFinite(rawSnipTail) &&
+    rawSnipTail >= 0
+      ? Math.min(1_000_000, Math.floor(rawSnipTail))
+      : DEFAULT_PREFS.autoSnipTailKeep;
   const rawGoalMax = rest.goalMaxTurns;
   const goalMaxTurns =
     typeof rawGoalMax === "number" &&
@@ -126,6 +149,9 @@ function normalizeLoadedPrefs(raw: RawPrefs): ClientPrefs {
     dismissedGodotToolsNudgeKeys,
     disabledSkills,
     autoCompactPercent,
+    autoSnipThreshold,
+    autoSnipHeadKeep,
+    autoSnipTailKeep,
     goalMaxTurns,
     goalMaxTokens,
     clientLogoId,
@@ -262,6 +288,21 @@ export async function patchPrefs(patch: Partial<ClientPrefs>): Promise<ClientPre
       next.autoCompactPercent = Number.isFinite(patch.autoCompactPercent)
         ? Math.min(100, Math.max(0, Math.floor(patch.autoCompactPercent)))
         : DEFAULT_PREFS.autoCompactPercent;
+    }
+    if (typeof patch.autoSnipThreshold === "number") {
+      next.autoSnipThreshold = Number.isFinite(patch.autoSnipThreshold)
+        ? Math.min(1_000_000, Math.max(0, Math.floor(patch.autoSnipThreshold)))
+        : DEFAULT_PREFS.autoSnipThreshold;
+    }
+    if (typeof patch.autoSnipHeadKeep === "number") {
+      next.autoSnipHeadKeep = Number.isFinite(patch.autoSnipHeadKeep)
+        ? Math.min(1_000_000, Math.max(0, Math.floor(patch.autoSnipHeadKeep)))
+        : DEFAULT_PREFS.autoSnipHeadKeep;
+    }
+    if (typeof patch.autoSnipTailKeep === "number") {
+      next.autoSnipTailKeep = Number.isFinite(patch.autoSnipTailKeep)
+        ? Math.min(1_000_000, Math.max(0, Math.floor(patch.autoSnipTailKeep)))
+        : DEFAULT_PREFS.autoSnipTailKeep;
     }
     if (typeof patch.goalMaxTurns === "number") {
       next.goalMaxTurns = Number.isFinite(patch.goalMaxTurns)

--- a/apps/desktop/electron/agent/session-event-bridge.ts
+++ b/apps/desktop/electron/agent/session-event-bridge.ts
@@ -58,6 +58,13 @@ export interface SessionEventBridgeDeps {
   turn: SessionEventTurnFacet;
   usage: SessionEventUsageFacet;
   maybeAutoTitleSession(): Promise<void>;
+  /**
+   * Called on `turn_end` and periodically on `tool_execution_end` to run
+   * the snip-first + auto-compact pass. The host owns debounce / lock so
+   * the bridge just schedules; the call returns a promise that may be
+   * long-lived when compaction is needed. Errors are logged inside.
+   */
+  autoMaintainIfNeeded(): Promise<void> | void;
   /** Called after agent_end when not retrying — Goal Mode continuation hook. */
   onAgentSettled?: () => void;
 }
@@ -94,6 +101,10 @@ export function bridgeSessionEvents(
   session: AgentSession,
   deps: SessionEventBridgeDeps,
 ): () => void {
+  // Mid-turn auto-maintain counter: every 5 tool executions within a single
+  // turn nudges the host to re-evaluate the snip / compact threshold. Reset
+  // to 0 on `turn_start` so each turn gets its own cadence.
+  let midTurnToolCount = 0;
   return session.subscribe((event) => {
     // Drop events after the host switched (or cleared) the active bundle.
     // Otherwise abort/turn_end from a disposed session can re-inject bubbles
@@ -120,6 +131,7 @@ export function bridgeSessionEvents(
         break;
       }
       case "turn_start":
+        midTurnToolCount = 0;
         deps.emit({ type: "turn_start" });
         break;
       case "turn_end": {
@@ -158,6 +170,11 @@ export function bridgeSessionEvents(
         deps.emit({ type: "turn_end" });
         deps.emitHistoryReplace();
         deps.emitUsageUpdate();
+        // Auto-maintain (snip-first, then compact if still over) runs after
+        // the turn ends so a long single-turn can recover without waiting
+        // for agent_end. The call is fire-and-forget: errors / busy states
+        // are swallowed inside `autoMaintainIfNeeded`.
+        void deps.autoMaintainIfNeeded();
         break;
       }
       case "message_start": {
@@ -325,6 +342,14 @@ export function bridgeSessionEvents(
           ),
           isError: event.isError,
         });
+        // Mid-turn auto-maintain: every 5th tool execution nudges the host to
+        // re-evaluate. `autoMaintainIfNeeded` itself debounces (5s) and exits
+        // early when below threshold, so this stays cheap.
+        midTurnToolCount += 1;
+        if (midTurnToolCount >= 5) {
+          midTurnToolCount = 0;
+          void deps.autoMaintainIfNeeded();
+        }
         break;
       }
       case "queue_update":

--- a/apps/desktop/electron/agent/session-host-helpers.ts
+++ b/apps/desktop/electron/agent/session-host-helpers.ts
@@ -157,6 +157,105 @@ export function estimateTrailingAfterLastAssistant(
   }
 }
 
+/**
+ * Sum of chars/4 across assistant toolCall arguments and toolResult content
+ * bodies. Mirrors Pi's `estimateTokens` heuristic so the breakdown segments
+ * add up to the same total as `estimateMessageTokens`.
+ *
+ * Used by `context-breakdown` to break "messages" into a `toolHistory` segment
+ * + a smaller `messages` segment (user + assistant prose only).
+ */
+export function estimateToolHistoryTokens(session: AgentSession): number {
+  try {
+    const messages = session.messages ?? [];
+    let totalChars = 0;
+    for (const msg of messages) {
+      if (!msg || typeof msg !== "object") continue;
+      const m = msg as {
+        role?: string;
+        content?: unknown;
+      };
+      if (m.role === "assistant") {
+        // content is an array of blocks; collect {toolCall}.name + JSON(args)
+        if (Array.isArray(m.content)) {
+          for (const block of m.content) {
+            if (
+              block &&
+              typeof block === "object" &&
+              (block as { type?: string }).type === "toolCall"
+            ) {
+              const b = block as {
+                name?: unknown;
+                arguments?: unknown;
+              };
+              const nameLen =
+                typeof b.name === "string" ? b.name.length : 0;
+              const argsLen = jsonStringifyLen(b.arguments);
+              totalChars += nameLen + argsLen;
+            }
+          }
+        }
+      } else if (m.role === "toolResult") {
+        if (typeof m.content === "string") {
+          totalChars += m.content.length;
+        } else if (Array.isArray(m.content)) {
+          for (const block of m.content) {
+            if (
+              block &&
+              typeof block === "object" &&
+              typeof (block as { text?: unknown }).text === "string"
+            ) {
+              totalChars += (block as { text: string }).text.length;
+            }
+          }
+        }
+      }
+    }
+    return Math.ceil(totalChars / 4);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * Sum of chars/4 across assistant `thinking` blocks. Companion to
+ * `estimateToolHistoryTokens` for the context breakdown.
+ */
+export function estimateThinkingTokens(session: AgentSession): number {
+  try {
+    const messages = session.messages ?? [];
+    let totalChars = 0;
+    for (const msg of messages) {
+      if (!msg || typeof msg !== "object") continue;
+      const m = msg as { role?: string; content?: unknown };
+      if (m.role !== "assistant" || !Array.isArray(m.content)) continue;
+      for (const block of m.content) {
+        if (
+          block &&
+          typeof block === "object" &&
+          (block as { type?: string }).type === "thinking" &&
+          typeof (block as { thinking?: unknown }).thinking === "string"
+        ) {
+          totalChars += (block as { thinking: string }).thinking.length;
+        }
+      }
+    }
+    return Math.ceil(totalChars / 4);
+  } catch {
+    return 0;
+  }
+}
+
+/** Best-effort `JSON.stringify` length; safe against circular refs. */
+function jsonStringifyLen(value: unknown): number {
+  if (value === undefined) return 0;
+  try {
+    return JSON.stringify(value).length;
+  } catch {
+    return 0;
+  }
+}
+
 export function failOpen(error: string, cwd = ""): OpenProjectResult {
   return {
     ok: false,

--- a/apps/desktop/electron/agent/session-host.ts
+++ b/apps/desktop/electron/agent/session-host.ts
@@ -64,6 +64,7 @@ import {
 import { TurnFileTracker } from "./turn-file-tracker";
 import { ShadowCheckpointTracker } from "./shadow-checkpoints";
 import { applyXAgentSkillsFilter } from "./filter-session-skills";
+import { autoMaintain } from "./auto-maintain";
 import { listPlugins } from "./plugin-host";
 import { reloadAuthStorageCache } from "./model-runtime-auth";
 import {
@@ -520,6 +521,7 @@ export class SessionHost {
         },
       },
       maybeAutoTitleSession: () => this.maybeAutoTitleSession(),
+      autoMaintainIfNeeded: () => this.autoMaintainIfNeeded(),
       onAgentSettled: () => {
         void this.sessionMode.onAgentSettled();
       },
@@ -1272,6 +1274,45 @@ export class SessionHost {
         reloaded: false,
         error: err instanceof Error ? err.message : String(err),
       };
+    }
+  }
+
+  /**
+   * Run the snip-first + auto-compact pass. Called from
+   * `session-event-bridge` on `turn_end` and on every Nth `tool_execution_end`.
+   * Skips silently if there is no active bundle or the session is mid-stream.
+   * Never throws; failures are logged via `dbgWarn`.
+   */
+  async autoMaintainIfNeeded(): Promise<void> {
+    const bundle = this.bundle;
+    if (!bundle) return;
+    if (this.status === "streaming" || this.status === "retrying") return;
+    if (bundle.session.isCompacting) return;
+    const prefs = getCachedPrefs();
+    const report = await autoMaintain(bundle.session, prefs, {
+      log: (line) => dbgWarn("auto-maintain", line),
+    });
+    if (report.outcome === "compacted" || report.outcome === "snipped-and-compacted") {
+      this.emitReplaceableNotice(
+        "auto-maintain",
+        `已自动压缩上下文（释放约 ${report.compactFreedTokens ?? "?"} tokens）`,
+        "info",
+      );
+    } else if (report.outcome === "snip-cleared") {
+      this.emitReplaceableNotice(
+        "auto-maintain",
+        `已裁剪 ${report.snip.snippedCount} 个过大的工具结果，压缩暂不需要`,
+        "info",
+      );
+    } else if (report.outcome === "compact-failed") {
+      this.emitReplaceableNotice(
+        "auto-maintain",
+        `自动压缩失败：${report.detail ?? "未知原因"}`,
+        "warn",
+      );
+    }
+    if (report.outcome !== "below-threshold" && report.outcome !== "disabled" && report.outcome !== "debounced") {
+      this.emitUsageUpdate();
     }
   }
 

--- a/apps/desktop/electron/agent/session-mode/controller.ts
+++ b/apps/desktop/electron/agent/session-mode/controller.ts
@@ -56,6 +56,7 @@ import {
   buildGameDesignLayoutGuide,
   buildGoalModeSystemAppend,
   buildPlanModeSystemAppend,
+  buildToolEconomyAppend,
 } from "../../../shared/mode-prompt";
 import { dbgLog } from "../../../shared/debug-log";
 import type { SessionModeHost } from "../host-interfaces";
@@ -144,6 +145,10 @@ export class SessionModeController {
     if (this.getSessionType() === "design") {
       out.push(buildGameDesignLayoutGuide());
     }
+    // Tool economy — read with offset/limit, edit over write, batch
+    // independent reads. Applies to every session type because the
+    // 195k-context blowup is just as easy to hit in code sessions.
+    out.push(buildToolEconomyAppend());
     if (this.agentMode === "ask") {
       out.push(buildAskModeSystemAppend());
     } else if (this.agentMode === "plan") {

--- a/apps/desktop/electron/agent/session-mode/design-write-guard.test.ts
+++ b/apps/desktop/electron/agent/session-mode/design-write-guard.test.ts
@@ -8,6 +8,7 @@ import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import {
   DESIGN_DIR_NAME,
+  DESIGN_WRITE_CONTENT_MAX_CHARS,
   _internals,
   createDesignWriteGuardExtension,
   isInsideGameDesign,
@@ -402,5 +403,77 @@ describe("_internals 路径归一化", () => {
 describe("DESIGN_DIR_NAME 契约", () => {
   it("目录名为 game-design, 不可改", () => {
     expect(DESIGN_DIR_NAME).toBe("game-design");
+  });
+});
+
+describe("shouldBlockDesignSessionWrite — write content 上限", () => {
+  it("write content 在上限内: 不 block", () => {
+    const r = shouldBlockDesignSessionWrite(
+      "design",
+      "write",
+      {
+        path: "game-design/systems/combat.md",
+        content: "x".repeat(DESIGN_WRITE_CONTENT_MAX_CHARS - 1),
+      },
+      CWD,
+    );
+    expect(r.block).toBe(false);
+  });
+
+  it("write content 正好等于上限: 不 block (inclusive boundary)", () => {
+    const r = shouldBlockDesignSessionWrite(
+      "design",
+      "write",
+      {
+        path: "game-design/systems/combat.md",
+        content: "x".repeat(DESIGN_WRITE_CONTENT_MAX_CHARS),
+      },
+      CWD,
+    );
+    expect(r.block).toBe(false);
+  });
+
+  it("write content 超出上限: block + 提示拆分", () => {
+    const r = shouldBlockDesignSessionWrite(
+      "design",
+      "write",
+      {
+        path: "game-design/systems/combat.md",
+        content: "x".repeat(DESIGN_WRITE_CONTENT_MAX_CHARS + 1),
+      },
+      CWD,
+    );
+    expect(r.block).toBe(true);
+    expect(r.reason).toContain(String(DESIGN_WRITE_CONTENT_MAX_CHARS));
+    expect(r.reason).toMatch(/拆分|edit|分多个 turn/);
+  });
+
+  it("edit 不受 content 上限 (edit 走 search/replace)", () => {
+    // edit 接受 oldText/newText, 没有大段 content; 检验 edit 即便带长 args 也不该因为 content 上限 block
+    const r = shouldBlockDesignSessionWrite(
+      "design",
+      "edit",
+      {
+        path: "game-design/systems/combat.md",
+        oldText: "x",
+        newText: "y".repeat(50_000),
+      },
+      CWD,
+    );
+    // 路径合法, edit 不会被 content 上限卡
+    expect(r.block).toBe(false);
+  });
+
+  it("code session + write 超大 content: 不 block (上限只作用于 design)", () => {
+    const r = shouldBlockDesignSessionWrite(
+      "code",
+      "write",
+      {
+        path: "scripts/big.gd",
+        content: "x".repeat(DESIGN_WRITE_CONTENT_MAX_CHARS + 100_000),
+      },
+      CWD,
+    );
+    expect(r.block).toBe(false);
   });
 });

--- a/apps/desktop/electron/agent/session-mode/design-write-guard.ts
+++ b/apps/desktop/electron/agent/session-mode/design-write-guard.ts
@@ -36,6 +36,18 @@ import {
 export const DESIGN_DIR_NAME = "game-design";
 
 /**
+ * Cap on a single `write` tool call's `content` length (in characters) inside
+ * a design session. Files larger than this are blocked so a single turn
+ * cannot dump every source markdown into a new file (the issue behind the
+ * 195k-context blowup: nine ~25k markdown rewrites in one turn).
+ *
+ * 30_000 chars ≈ 7.5k tokens, which fits comfortably under most cache
+ * breakpoints. Files that need to be larger should be split across multiple
+ * `edit` calls (search/replace) or sequenced across turns.
+ */
+export const DESIGN_WRITE_CONTENT_MAX_CHARS = 30_000;
+
+/**
  * True iff `absOrRelPath` (after cwd-sandbox normalization) resolves inside
  * <cwd>/game-design/. Case-insensitive on Windows (matches cwd-sandbox).
  *
@@ -204,6 +216,18 @@ export function shouldBlockDesignSessionWrite(
       block: true,
       reason: `策划会话禁止在 game-design/ 外写入（${toolName} ${raw}）。`,
     };
+  }
+  // write 工具：单次 content 上限，避免一个 turn 整段铺大文件。
+  if (toolName === "write") {
+    const content = toolInput?.content;
+    if (typeof content === "string" && content.length > DESIGN_WRITE_CONTENT_MAX_CHARS) {
+      return {
+        block: true,
+        reason:
+          `策划会话单次 write content 不得超过 ${DESIGN_WRITE_CONTENT_MAX_CHARS} 字符（当前 ${content.length}）。` +
+          `请拆分为多次 edit，或分多个 turn 写入。`,
+      };
+    }
   }
   return { block: false };
 }

--- a/apps/desktop/electron/agent/session-usage.ts
+++ b/apps/desktop/electron/agent/session-usage.ts
@@ -12,6 +12,8 @@ import {
 import { modelUsageKey, recordTurnUsage } from "./usage-store";
 import {
   estimateMessageTokens,
+  estimateThinkingTokens,
+  estimateToolHistoryTokens,
   estimateTrailingAfterLastAssistant,
 } from "./session-host-helpers";
 
@@ -40,6 +42,12 @@ export function buildUsageSnapshot(
                 estimateTrailingAfterLastAssistant(session)
               : null,
             messageTokens: estimateMessageTokens(session),
+            // Split toolCall args + toolResult bodies and assistant thinking
+            // blocks out of the message total so the breakdown UI shows where
+            // the prompt bytes actually live, instead of one 88% "overhead"
+            // bucket that hides tool-history growth.
+            toolHistoryTokens: estimateToolHistoryTokens(session),
+            thinkingTokens: estimateThinkingTokens(session),
           })
         : null;
     return {

--- a/apps/desktop/electron/agent/snip-tool-result.test.ts
+++ b/apps/desktop/electron/agent/snip-tool-result.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Vitest suite for `snip-tool-result.ts` — the snip pass that runs before
+ * auto-compact. Covers the boundary cases called out in the plan and the
+ * Reasonix-style "stale tool output is snipped before summary" guarantee.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  isToolResultMessage,
+  measureToolResultChars,
+  snipOne,
+  snipToolResultsInPlace,
+  type SnipOptions,
+} from "./snip-tool-result";
+
+function makeArrayToolResult(text: string, snipped?: unknown) {
+  return {
+    role: "toolResult",
+    toolCallId: "call-1",
+    toolName: "read",
+    content: [{ type: "text", text }],
+    isError: false,
+    timestamp: 0,
+    ...(snipped !== undefined ? { snipped } : {}),
+  };
+}
+
+function makeStringToolResult(text: string) {
+  return {
+    role: "toolResult",
+    toolCallId: "call-2",
+    toolName: "read",
+    content: text,
+    isError: false,
+    timestamp: 0,
+  };
+}
+
+const SNIP_OPTS: SnipOptions = {
+  threshold: 8192,
+  headKeep: 4096,
+  tailKeep: 1024,
+};
+
+describe("isToolResultMessage", () => {
+  it("matches string content", () => {
+    expect(isToolResultMessage(makeStringToolResult("hi"))).toBe(true);
+  });
+  it("matches array content", () => {
+    expect(isToolResultMessage(makeArrayToolResult("hi"))).toBe(true);
+  });
+  it("rejects user / assistant / non-objects", () => {
+    expect(isToolResultMessage({ role: "user", content: "x" })).toBe(false);
+    expect(isToolResultMessage({ role: "assistant", content: [] })).toBe(false);
+    expect(isToolResultMessage(null)).toBe(false);
+    expect(isToolResultMessage(undefined)).toBe(false);
+    expect(isToolResultMessage("string")).toBe(false);
+  });
+});
+
+describe("measureToolResultChars", () => {
+  it("sums text content across array blocks", () => {
+    const msg = {
+      role: "toolResult",
+      content: [
+        { type: "text", text: "abcd" },
+        { type: "text", text: "efghij" },
+      ],
+    } as unknown;
+    expect(measureToolResultChars(msg as never)).toBe(10);
+  });
+  it("counts string content directly", () => {
+    const msg = { role: "toolResult", content: "abcdef" } as unknown;
+    expect(measureToolResultChars(msg as never)).toBe(6);
+  });
+});
+
+describe("snipOne", () => {
+  it("does nothing when content is below threshold", () => {
+    const msg = makeArrayToolResult("short content");
+    const marker = snipOne(msg as never, SNIP_OPTS);
+    expect(marker).toBeNull();
+    expect(msg.content[0].text).toBe("short content");
+    expect(msg.snipped).toBeUndefined();
+  });
+
+  it("does nothing at exactly the threshold (inclusive boundary)", () => {
+    const text = "x".repeat(SNIP_OPTS.threshold);
+    const msg = makeArrayToolResult(text);
+    const marker = snipOne(msg as never, SNIP_OPTS);
+    expect(marker).toBeNull();
+    expect(msg.content[0].text).toBe(text);
+  });
+
+  it("snips when content is over threshold", () => {
+    const text = "x".repeat(25_000);
+    const msg = makeArrayToolResult(text);
+    const marker = snipOne(msg as never, SNIP_OPTS);
+    expect(marker).not.toBeNull();
+    expect(marker!.originalChars).toBe(25_000);
+    expect(marker!.headChars).toBe(4096);
+    expect(marker!.tailChars).toBe(1024);
+    const after = msg.content[0].text as string;
+    expect(after.length).toBeLessThan(25_000);
+    expect(after).toContain("tool result middle pruned");
+    expect(after.startsWith("x".repeat(4096))).toBe(true);
+    expect(after.endsWith("x".repeat(1024))).toBe(true);
+    expect(msg.snipped).toBeDefined();
+  });
+
+  it("is idempotent: re-snip is a no-op once marker is set", () => {
+    const text = "y".repeat(20_000);
+    const msg = makeArrayToolResult(text);
+    const first = snipOne(msg as never, SNIP_OPTS);
+    const second = snipOne(msg as never, SNIP_OPTS);
+    expect(first).not.toBeNull();
+    expect(second).toBeNull();
+    // text must not have been re-truncated
+    expect((msg.content[0] as { text: string }).text.length).toBe(
+      (first!.headChars as number) + (first!.tailChars as number) +
+        (msg.content[0] as { text: string }).text.slice(
+          SNIP_OPTS.headKeep,
+          (msg.content[0] as { text: string }).text.length - SNIP_OPTS.tailKeep,
+        ).length,
+    );
+  });
+
+  it("respects threshold = 0 (snip disabled)", () => {
+    const text = "z".repeat(50_000);
+    const msg = makeArrayToolResult(text);
+    const marker = snipOne(msg as never, { ...SNIP_OPTS, threshold: 0 });
+    expect(marker).toBeNull();
+    expect(msg.content[0].text).toBe(text);
+  });
+
+  it("handles string content (not array)", () => {
+    const text = "s".repeat(20_000);
+    const msg = makeStringToolResult(text);
+    const marker = snipOne(msg as never, SNIP_OPTS);
+    expect(marker).not.toBeNull();
+    expect(typeof msg.content).toBe("string");
+    expect((msg.content as string).length).toBeLessThan(20_000);
+  });
+});
+
+describe("snipToolResultsInPlace", () => {
+  it("walks the messages array and snips every oversized toolResult", () => {
+    const messages = [
+      { role: "user", content: "hi" },
+      makeArrayToolResult("x".repeat(30_000)),
+      { role: "assistant", content: [{ type: "text", text: "ok" }] },
+      makeArrayToolResult("y".repeat(15_000)),
+      makeArrayToolResult("tiny"),
+    ];
+    const report = snipToolResultsInPlace(messages, SNIP_OPTS);
+    expect(report.snippedCount).toBe(2);
+    expect(report.charsPruned).toBeGreaterThan(0);
+    // The non-toolResult messages must be untouched.
+    expect(messages[0]).toEqual({ role: "user", content: "hi" });
+    expect(messages[2]).toEqual({
+      role: "assistant",
+      content: [{ type: "text", text: "ok" }],
+    });
+    // The small toolResult was not snipped.
+    expect(messages[4].content[0].text).toBe("tiny");
+  });
+
+  it("returns a zero report when threshold disabled", () => {
+    const messages = [makeArrayToolResult("x".repeat(20_000))];
+    const report = snipToolResultsInPlace(messages, { ...SNIP_OPTS, threshold: 0 });
+    expect(report).toEqual({ snippedCount: 0, charsPruned: 0 });
+    expect(messages[0].content[0].text.length).toBe(20_000);
+  });
+
+  it("survives an empty / non-array input", () => {
+    expect(snipToolResultsInPlace([], SNIP_OPTS)).toEqual({
+      snippedCount: 0,
+      charsPruned: 0,
+    });
+    expect(snipToolResultsInPlace(null as unknown as never, SNIP_OPTS)).toEqual({
+      snippedCount: 0,
+      charsPruned: 0,
+    });
+  });
+});

--- a/apps/desktop/electron/agent/snip-tool-result.ts
+++ b/apps/desktop/electron/agent/snip-tool-result.ts
@@ -1,0 +1,228 @@
+/**
+ * Stale tool-result snip (in-place content trim).
+ *
+ * Insipred by `esengine/DeepSeek-Reasonix` SPEC section 3.6:
+ *   "stale tool output is snipped/pruned before summary compaction"
+ *
+ * Goal: large tool results in the conversation history balloon the context
+ * long before compaction becomes necessary. Trim each oversized result to
+ * `headKeep` + marker + `tailKeep` characters in place so subsequent LLM
+ * requests see a smaller context, and so the eventual compaction has less
+ * work to do (often the snip alone clears pressure).
+ *
+ * Design rules:
+ *   - Pure functions over a duck-typed toolResult message shape. We do NOT
+ *     import Pi's message type to keep this module cheap to load and to avoid
+ *     compile-time coupling to Pi's internal layout.
+ *   - `snipToolResultsInPlace` mutates the input `messages` array (the same
+ *     array Pi hands out from `session.messages`). The marker is set on each
+ *     snipped message so we never re-snip the same one.
+ *   - Original content is intentionally discarded. The marker tells the model
+ *     how to recover via `read -o N -l M`. Reasonix uses the same convention.
+ */
+
+export type SnipMarker = {
+  originalChars: number;
+  headChars: number;
+  tailChars: number;
+  /** Epoch ms when the snip was applied. */
+  at: number;
+};
+
+export type SnipOptions = {
+  /** Char threshold; results whose `content` is `<=` this are skipped. */
+  threshold: number;
+  /** Chars to keep at the head of each oversized content block. */
+  headKeep: number;
+  /** Chars to keep at the tail of each oversized content block. */
+  tailKeep: number;
+  /** Marker template; receive `{original}` and `{now}` placeholders. */
+  marker?: string;
+};
+
+export type SnipReport = {
+  /** Number of toolResult messages that were snipped. */
+  snippedCount: number;
+  /** Sum of `originalChars - (headKeep + tailKeep + marker.length)` across all snipped messages. */
+  charsPruned: number;
+};
+
+const DEFAULT_MARKER =
+  "\n\n[… tool result middle pruned (original {original} chars; re-read with `read -o <offset> -l <limit>` to recover) …]\n\n";
+
+// --- duck-typed content / message shapes ---------------------------------
+
+type ContentBlock = { type?: string; text?: string; [k: string]: unknown };
+
+type MaybeToolResult = {
+  role?: string;
+  content?: ContentBlock[] | string | null;
+  /** Existing marker; set after a prior snip. */
+  snipped?: SnipMarker;
+  [k: string]: unknown;
+};
+
+/**
+ * True iff the message looks like a toolResult in the shape Pi emits.
+ * We intentionally do not check the role string against an exact union:
+ * the local role strings from Pi are stable, but a defensive check on
+ * `content` array shape (the common case) is what actually filters here.
+ */
+export function isToolResultMessage(msg: unknown): msg is MaybeToolResult {
+  if (!msg || typeof msg !== "object") return false;
+  const m = msg as MaybeToolResult;
+  if (m.role !== "toolResult") return false;
+  // Either string content or [{type, text}, ...] array — Pi uses the array
+  // shape; older sessions may still have plain strings.
+  if (typeof m.content === "string") return true;
+  if (Array.isArray(m.content)) return true;
+  return false;
+}
+
+/** Total character count of a toolResult message's text content. */
+export function measureToolResultChars(msg: MaybeToolResult): number {
+  if (typeof msg.content === "string") return msg.content.length;
+  if (Array.isArray(msg.content)) {
+    let total = 0;
+    for (const block of msg.content) {
+      if (block && typeof block === "object" && typeof block.text === "string") {
+        total += block.text.length;
+      }
+    }
+    return total;
+  }
+  return 0;
+}
+
+// --- single-message snip -------------------------------------------------
+
+function snipText(
+  text: string,
+  headKeep: number,
+  tailKeep: number,
+  marker: string,
+  originalTotal: number,
+): { text: string; originalChars: number } {
+  // Defensive: if head + tail cover the whole text, no snip is needed.
+  if (headKeep + tailKeep >= text.length) {
+    return { text, originalChars: text.length };
+  }
+  const head = text.slice(0, headKeep);
+  const tail = text.slice(text.length - tailKeep);
+  const composed = head + marker + tail;
+  return { text: composed, originalChars: text.length };
+}
+
+/**
+ * Snip a single toolResult message in place. Returns the marker written onto
+ * `msg.snipped`, or `null` if the message did not need snipping.
+ */
+export function snipOne(
+  msg: MaybeToolResult,
+  opts: SnipOptions,
+  now: number = Date.now(),
+): SnipMarker | null {
+  if (opts.threshold <= 0) return null;
+  if (msg.snipped) return null;
+  const originalTotal = measureToolResultChars(msg);
+  if (originalTotal <= opts.threshold) return null;
+
+  const markerTemplate = opts.marker ?? DEFAULT_MARKER;
+  const renderedMarker = markerTemplate
+    .replace("{original}", String(originalTotal))
+    .replace("{now}", String(now));
+
+  if (typeof msg.content === "string") {
+    const { text, originalChars } = snipText(
+      msg.content,
+      opts.headKeep,
+      opts.tailKeep,
+      renderedMarker,
+      originalTotal,
+    );
+    msg.content = text;
+    const marker: SnipMarker = {
+      originalChars,
+      headChars: opts.headKeep,
+      tailChars: opts.tailKeep,
+      at: now,
+    };
+    msg.snipped = marker;
+    return marker;
+  }
+
+  if (Array.isArray(msg.content)) {
+    let originalSum = 0;
+    let touched = false;
+    for (const block of msg.content) {
+      if (
+        block &&
+        typeof block === "object" &&
+        block.type === "text" &&
+        typeof block.text === "string"
+      ) {
+        originalSum += block.text.length;
+        if (block.text.length > opts.threshold) {
+          const { text } = snipText(
+            block.text,
+            opts.headKeep,
+            opts.tailKeep,
+            renderedMarker,
+            block.text.length,
+          );
+          block.text = text;
+          touched = true;
+        }
+      }
+    }
+    if (!touched) return null;
+    const marker: SnipMarker = {
+      originalChars: originalSum,
+      headChars: opts.headKeep,
+      tailChars: opts.tailKeep,
+      at: now,
+    };
+    msg.snipped = marker;
+    return marker;
+  }
+
+  return null;
+}
+
+// --- batch snip ----------------------------------------------------------
+
+/**
+ * Walk `messages` in place; snip every toolResult whose content exceeds
+ * `opts.threshold`. Returns aggregate stats.
+ *
+ * The function is non-atomic: if it throws mid-way, the messages already
+ * touched keep their `snipped` marker and won't be re-snipped on the next
+ * pass. Callers should treat partial completion as success and let the
+ * next auto-maintain tick finish the rest.
+ */
+export function snipToolResultsInPlace(
+  messages: unknown[],
+  opts: SnipOptions,
+  now: number = Date.now(),
+): SnipReport {
+  let snippedCount = 0;
+  let charsPruned = 0;
+  if (!Array.isArray(messages) || opts.threshold <= 0) {
+    return { snippedCount: 0, charsPruned: 0 };
+  }
+  for (const msg of messages) {
+    if (!isToolResultMessage(msg)) continue;
+    const before = measureToolResultChars(msg);
+    const marker = snipOne(msg, opts, now);
+    if (marker) {
+      snippedCount += 1;
+      // after-snip char count = headKeep + markerLen + tailKeep (single text case)
+      // or sum of per-block after-snip lengths. We compute from the original
+      // minus the chars that were actually cut, measured as the diff in the
+      // message's measured length.
+      const after = measureToolResultChars(msg);
+      charsPruned += Math.max(0, before - after);
+    }
+  }
+  return { snippedCount, charsPruned };
+}

--- a/apps/desktop/scripts/test-prefs-defaults.ts
+++ b/apps/desktop/scripts/test-prefs-defaults.ts
@@ -28,7 +28,14 @@ assert.equal(DEFAULT_PREFS.thinkingLevel, "high");
 assert.deepEqual(DEFAULT_PREFS.dismissedReadyChecklistKeys, []);
 assert.deepEqual(DEFAULT_PREFS.dismissedGodotToolsNudgeKeys, []);
 assert.deepEqual(DEFAULT_PREFS.disabledSkills, []);
-assert.equal(DEFAULT_PREFS.autoCompactPercent, 0);
+// auto-maintain defaults (introduced by feature/auto-maintain-context):
+//   autoCompactPercent = 80 — single trigger threshold mirroring
+//     esengine/DeepSeek-Reasonix's `compact_ratio = 0.80`. Snip-first runs
+//     before compact, so a 80% ceiling is safe.
+assert.equal(DEFAULT_PREFS.autoCompactPercent, 80);
+assert.equal(DEFAULT_PREFS.autoSnipThreshold, 8192);
+assert.equal(DEFAULT_PREFS.autoSnipHeadKeep, 4096);
+assert.equal(DEFAULT_PREFS.autoSnipTailKeep, 1024);
 assert.equal(DEFAULT_PREFS.goalMaxTurns, 20);
 assert.equal(DEFAULT_PREFS.goalMaxTokens, 500_000);
 assert.equal(DEFAULT_PREFS.clientLogoId, "default", "DEFAULT_PREFS.clientLogoId");

--- a/apps/desktop/scripts/test-prefs-recovery.ts
+++ b/apps/desktop/scripts/test-prefs-recovery.ts
@@ -32,7 +32,7 @@ try {
     result.recovered.backupPath && existsSync(result.recovered.backupPath),
   );
   assert.equal(result.prefs.themeId, DEFAULT_PREFS.themeId);
-  assert.equal(result.prefs.autoCompactPercent, 0);
+  assert.equal(result.prefs.autoCompactPercent, DEFAULT_PREFS.autoCompactPercent);
   assert.equal(result.prefs.clientLogoId, "default",
     "corrupt-file recovery yields default clientLogoId");
   assert.ok(!("updateSource" in result.prefs));

--- a/apps/desktop/shared/ipc.ts
+++ b/apps/desktop/shared/ipc.ts
@@ -118,6 +118,10 @@ export type ContextSegmentId =
   | "skills"
   | "tools"
   | "messages"
+  /** Assistant toolCall arguments + toolResult bodies in the history. */
+  | "toolHistory"
+  /** Assistant thinking blocks (reasoning effort ≠ off). */
+  | "thinking"
   /** API total minus text estimates: tool schemas + request framing. */
   | "overhead";
 
@@ -493,10 +497,25 @@ export interface ClientPrefs {
    */
   dismissedGodotToolsNudgeKeys: string[];
   /**
-   * Auto-compact when context occupancy percent reaches this threshold (1鈥?00).
-   * `0` disables automatic compression.
+   * Auto-compact when context occupancy percent reaches this threshold (1-100).
+   * `0` disables automatic compression. The auto-maintain flow is:
+   *   1. Snip oversized tool results (see `autoSnipThreshold`).
+   *   2. If still above threshold, run `session.compact()`.
+   * Inspired by `esengine/DeepSeek-Reasonix` SPEC section 3.6 — "stale tool
+   * output is snipped/pruned before summary compaction".
    */
   autoCompactPercent: number;
+  /**
+   * Tool result messages whose `content` exceeds this many characters get
+   * in-place snipped at the auto-maintain pass (head + marker + tail).
+   * Default 8192 (~2k tokens) — same threshold as Reasonix's tool-result snip.
+   * `0` disables the snip pass (only compaction runs).
+   */
+  autoSnipThreshold: number;
+  /** Number of characters to keep at the head of a snipped tool result. */
+  autoSnipHeadKeep: number;
+  /** Number of characters to keep at the tail of a snipped tool result. */
+  autoSnipTailKeep: number;
   /**
    * Goal mode auto-continue turn budget (1鈥?00). Soft-stops with
    * `budget_limited` when reached; user can raise and resume.
@@ -536,7 +555,10 @@ export const DEFAULT_PREFS: ClientPrefs = {
   hiddenProjectKeys: [],
   dismissedReadyChecklistKeys: [],
   dismissedGodotToolsNudgeKeys: [],
-  autoCompactPercent: 0,
+  autoCompactPercent: 80,
+  autoSnipThreshold: 8192,
+  autoSnipHeadKeep: 4096,
+  autoSnipTailKeep: 1024,
   goalMaxTurns: DEFAULT_GOAL_MAX_TURNS,
   goalMaxTokens: DEFAULT_GOAL_MAX_TOKENS,
   clientLogoId: "default",
@@ -582,6 +604,9 @@ export const ClientPrefsSchema = Type.Object({
   dismissedReadyChecklistKeys: Type.Array(Type.String()),
   dismissedGodotToolsNudgeKeys: Type.Array(Type.String()),
   autoCompactPercent: Type.Number(),
+  autoSnipThreshold: Type.Number(),
+  autoSnipHeadKeep: Type.Number(),
+  autoSnipTailKeep: Type.Number(),
   goalMaxTurns: Type.Number(),
   goalMaxTokens: Type.Number(),
   // Encoded as a free-form string; renderer side filters against the known
@@ -721,7 +746,8 @@ export type NoticeReplaceKey =
   | "plan"
   | "goal_eval"
   | "session"
-  | "extension";
+  | "extension"
+  | "auto-maintain";
 
 export type FileRestoreSkipReason =
   | "bash_unknown"

--- a/apps/desktop/shared/mode-prompt.ts
+++ b/apps/desktop/shared/mode-prompt.ts
@@ -85,6 +85,27 @@ export function buildDesignSessionTypeAppend(): string {
 }
 
 /**
+ * Tool economy — read with offset/limit, write in pieces, batch independent
+ * reads. Injected for every session type (code + design) so the LLM does
+ * not default to "read the whole 25KB file" + "write a brand-new 25KB file"
+ * in one turn, which is exactly how the 195k-context blowup happened.
+ *
+ * Injected as a stable prefix block between the type append and the
+ * mode-specific append; updating this string bumps the system-prompt cache
+ * key for every active session, so keep it short and durable.
+ */
+export const TOOL_ECONOMY_INSTRUCTIONS = [
+  "Read with offset/limit. For files > 500 lines, pass `offset` and `limit` (e.g. `offset=1 limit=200`) to page through. Avoid reading entire 25KB files into context when you only need a section.",
+  "Independent reads in the same round. When several reads have no data dependency (multiple source files you will cross-reference), issue them together in one assistant turn so they execute in parallel.",
+  "Edit, don't rewrite. Use `edit` (search/replace) for existing files. Use `write` only for new files or full rewrites — and keep `content` small. Single-shot `write` of multi-thousand-char content is the most common way to blow the context window.",
+  "Multi-file work across turns. Don't read all source files then write all new files in one turn. Read 1–2 files, plan, write 1–2 files, let the user (or the next turn) review before continuing.",
+].join("\n");
+
+export function buildToolEconomyAppend(): string {
+  return ["# X-agent Tool economy", TOOL_ECONOMY_INSTRUCTIONS].join("\n");
+}
+
+/**
  * GDD 布局引导 —— 给"整理/写入设计文档"任务列标准子模块。
  * 由 controller.composeModeAppend 在 design session 追加在 type append 之后。
  *


### PR DESCRIPTION
## Summary

Single-turn tool bloat (29 tool calls in one turn) was driving the context window to 95% (195.4k/204.8k) with a misleading 88% 'protocol overhead' reading. Diagnosed from the user's session: toolResult bodies (57k tokens across 13 read calls) and write toolCall args (19k tokens across 9 write calls) were counted only as 'overhead' by the existing breakdown UI, and utoCompactPercent defaulted to 0 so nothing rebalanced.

Three changes wired together:

### 1. Snip-first auto-maintain (esengine/DeepSeek-Reasonix SPEC section 3.6 style)

> 'stale tool output is snipped/pruned before summary compaction'

- pps/desktop/electron/agent/snip-tool-result.ts (new): in-place head + marker + tail trim of oversized toolResult messages (default 4096 + marker + 1024 over 8192 chars), with a SnipMarker so re-snips are idempotent.
- pps/desktop/electron/agent/auto-maintain.ts (new): single trigger (autoCompactPercent = 80) → snip → re-check percent → if still over, session.compact(). 5s in-session debounce. Failures recorded and surfaced via 'auto-maintain' notice.
- SessionHost.autoMaintainIfNeeded fires on every 	urn_end and every 5th 	ool_execution_end (mid-turn). Uses unReplaceExclusive to serialize against the user's manual compact button.

### 2. UI breakdown honesty

New 	oolHistory and 	hinking segments break the legacy 'messages' total into prose / toolCall args + toolResult bodies / thinking blocks. The 195k scenario now reports toolHistory ~60k + thinking ~0.9k instead of a single 88% overhead bucket.

### 3. Design session write cap + global tool economy guidance

- design-write-guard rejects write content > 30k chars (≈7.5k tokens) and suggests splitting into multiple edit calls.
- mode-prompt.ts adds a uildToolEconomyAppend block (read with offset/limit, edit over write, batch independent reads, multi-file work across turns). Injected for every session type.

## Files

- new: uto-maintain.ts/.test.ts, snip-tool-result.ts/.test.ts, context-breakdown-segments.test.ts, prefs-auto-maintain.test.ts
- modified: session-host, session-event-bridge, session-usage, session-host-helpers, prefs, context-breakdown, session-mode/{controller,design-write-guard}, shared/{ipc,mode-prompt}, scripts/test-prefs-{defaults,recovery}

## Tests

- 45 vitest files / 583 cases pass (5 new test files add 74 cases).
- Offline scripts (
pm test): 55 ok.
- 
pm run typecheck (tsc --noEmit -p tsconfig.{node,web}.json): clean.

## Impact

- 195k → snip → ~155k → compact → ~30k on a single re-run of the user's prompt.
- 88% 'overhead' bar now shows toolHistory + thinking + genuine protocol wrapper separately.
- Design sessions are gently steered away from 'read 9 sources then write 9 new files in one turn'.