### PR TITLE
fix(agent): completion discipline system append + max_tokens 自动 retry

### DIFF
--- a/apps/desktop/electron/agent/session-event-bridge.test.ts
+++ b/apps/desktop/electron/agent/session-event-bridge.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Vitest suite — session-event-bridge truncation detection.
+ *
+ * Locks the rule: when an assistant message ends with stopReason="length"
+ * and contains no text / no tool call (only thinking), the host must be
+ * notified via `deps.notifyTruncation` so it can inject a recovery prompt.
+ *
+ * 5 cases:
+ *  - 4 on the pure helper `isTruncatedThinkingOnly`
+ *  - 1 on `bridgeSessionEvents` calling `deps.notifyTruncation` for a
+ *    truncated thinking-only message
+ *
+ * The bridge integration uses a minimal Pi-AgentSession mock: we only
+ * need the `subscribe(handler)` shape. Real Pi events are typed but the
+ * bridge is defensive (`as`-cast + null guards), so a hand-rolled
+ * fake covers the contract we care about.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { isTruncatedThinkingOnly, bridgeSessionEvents } from "./session-event-bridge";
+
+describe("isTruncatedThinkingOnly", () => {
+  it("length + 仅 thinking → true", () => {
+    expect(
+      isTruncatedThinkingOnly({
+        stopReason: "length",
+        content: [{ type: "thinking", thinking: "long analysis…" }],
+      }),
+    ).toBe(true);
+  });
+
+  it("length + 包含 text → false (文本已落,模型有输出)", () => {
+    expect(
+      isTruncatedThinkingOnly({
+        stopReason: "length",
+        content: [{ type: "text", text: "部分结论" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("length + 包含 toolCall → false (模型已动手,非撞墙)", () => {
+    expect(
+      isTruncatedThinkingOnly({
+        stopReason: "length",
+        content: [
+          { type: "thinking", thinking: "analyzing…" },
+          { type: "toolCall", name: "read" },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("stop (end_turn) + 仅 thinking → false (正常 end_turn,非截断)", () => {
+    expect(
+      isTruncatedThinkingOnly({
+        stopReason: "stop",
+        content: [{ type: "thinking", thinking: "short" }],
+      }),
+    ).toBe(false);
+  });
+
+  it("length + 空 content → true (撞墙 + 完全无输出,极端 case)", () => {
+    expect(
+      isTruncatedThinkingOnly({
+        stopReason: "length",
+        content: [],
+      }),
+    ).toBe(true);
+  });
+
+  it("null / 非对象输入 → false (防御性)", () => {
+    expect(isTruncatedThinkingOnly(null)).toBe(false);
+    expect(isTruncatedThinkingOnly(undefined)).toBe(false);
+    expect(isTruncatedThinkingOnly("not an object")).toBe(false);
+    expect(isTruncatedThinkingOnly(42)).toBe(false);
+  });
+});
+
+describe("bridgeSessionEvents → notifyTruncation hook", () => {
+  /**
+   * Build a minimal Pi-AgentSession-like object that records its event
+   * handler and lets the test push events through it. Real AgentSession
+   * has a much wider surface; the bridge only uses `subscribe(handler)`.
+   *
+   * Important: the SAME object must be returned by `deps.getSession()` and
+   * passed to `bridgeSessionEvents` — the bridge drops events where they
+   * don't match (defensive against bundle switches mid-turn).
+   */
+  function makeFakeSession() {
+    let handler: ((event: unknown) => void) | null = null;
+    const obj = {
+      sessionId: "test-session-id",
+      subscribe: (h: (event: unknown) => void) => {
+        handler = h;
+        return () => {
+          handler = null;
+        };
+      },
+      push: (event: unknown) => {
+        if (!handler) throw new Error("bridge not subscribed");
+        handler(event);
+      },
+    };
+    return obj;
+  }
+
+  /**
+   * Build a minimal deps object — the bridge only touches these fields
+   * for the notifyTruncation hook. Real deps has more; we cast to keep
+   * the test compact.
+   */
+  function makeDeps(overrides: Record<string, unknown> = {}) {
+    const fakeSession = (overrides.session as ReturnType<typeof makeFakeSession>) ?? makeFakeSession();
+    return {
+      emit: vi.fn(),
+      setStatus: vi.fn(),
+      setLastErrorSilently: vi.fn(),
+      emitUsageUpdate: vi.fn(),
+      emitHistoryReplace: vi.fn(),
+      messageIdFrom: () => "msg-id-1",
+      toolDetails: new Map(),
+      // 关键:getSession 必须返回与 bridgeSessionEvents 第一个参数相同的对象
+      getSession: () => fakeSession,
+      turn: {
+        fileTracker: { getActiveUserEntryId: () => undefined, setActiveUserEntryId: () => {} },
+        shadowCheckpoints: { bindPendingPre: () => {}, getCheckpoint: () => undefined, persistDirty: () => {} },
+        currentUserEntryId: () => undefined,
+      },
+      usage: {
+        setLastTurnUsage: () => {},
+        isCompactionRecording: () => false,
+        setCompactionRecording: () => {},
+        captureCompactionBaseline: () => {},
+        recordCompactionDelta: () => {},
+        clearCompactionBaseline: () => {},
+      },
+      maybeAutoTitleSession: () => Promise.resolve(),
+      autoMaintainIfNeeded: () => {},
+      onAgentSettled: () => {},
+      notifyTruncation: vi.fn(),
+      ...overrides,
+    };
+  }
+
+  it("max_tokens + 仅 thinking → 调用 deps.notifyTruncation({messageId, outputTokens})", () => {
+    const fakeSession = makeFakeSession();
+    const deps = makeDeps({ session: fakeSession, messageIdFrom: () => "msg-id-1" });
+
+    const unsubscribe = bridgeSessionEvents(
+      fakeSession as unknown as Parameters<typeof bridgeSessionEvents>[0],
+      deps as unknown as Parameters<typeof bridgeSessionEvents>[1],
+    );
+
+    fakeSession.push({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        stopReason: "length",
+        content: [{ type: "thinking", thinking: "deep but truncated" }],
+        usage: { output: 16384, reasoning: 16383 },
+      },
+    });
+
+    expect(deps.notifyTruncation).toHaveBeenCalledTimes(1);
+    expect(deps.notifyTruncation).toHaveBeenCalledWith({
+      messageId: "msg-id-1",
+      outputTokens: 16384,
+    });
+
+    unsubscribe();
+  });
+
+  it("正常 end_turn (stop) → 不调用 notifyTruncation", () => {
+    const fakeSession = makeFakeSession();
+    const deps = makeDeps({ session: fakeSession, messageIdFrom: () => "msg-id-2" });
+
+    bridgeSessionEvents(
+      fakeSession as unknown as Parameters<typeof bridgeSessionEvents>[0],
+      deps as unknown as Parameters<typeof bridgeSessionEvents>[1],
+    );
+
+    fakeSession.push({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        stopReason: "stop",
+        content: [{ type: "thinking", thinking: "short" }, { type: "text", text: "done" }],
+      },
+    });
+
+    expect(deps.notifyTruncation).not.toHaveBeenCalled();
+  });
+
+  it("notifyTruncation 未注入时 (老 host) → 不抛错,正常 emit assistant_end", () => {
+    const fakeSession = makeFakeSession();
+    const emit = vi.fn();
+    const deps = {
+      ...makeDeps({ session: fakeSession, messageIdFrom: () => "msg-id-3", emit }),
+      // 故意不传 notifyTruncation
+      notifyTruncation: undefined,
+    };
+
+    expect(() =>
+      bridgeSessionEvents(
+        fakeSession as unknown as Parameters<typeof bridgeSessionEvents>[0],
+        deps as unknown as Parameters<typeof bridgeSessionEvents>[1],
+      ),
+    ).not.toThrow();
+
+    expect(() =>
+      fakeSession.push({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          stopReason: "length",
+          content: [{ type: "thinking", thinking: "truncated" }],
+        },
+      }),
+    ).not.toThrow();
+
+    // assistant_end 仍正常 emit
+    expect(emit).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "assistant_end" }),
+    );
+  });
+});

--- a/apps/desktop/electron/agent/session-event-bridge.ts
+++ b/apps/desktop/electron/agent/session-event-bridge.ts
@@ -67,6 +67,17 @@ export interface SessionEventBridgeDeps {
   autoMaintainIfNeeded(): Promise<void> | void;
   /** Called after agent_end when not retrying — Goal Mode continuation hook. */
   onAgentSettled?: () => void;
+  /**
+   * Called when an assistant message ends with `stopReason: "length"` AND the
+   * content has no text / no tool call (only thinking). The host decides whether
+   * to inject a system-recovery prompt up to a per-session cap.
+   *
+   * Root cause: M3 + thinking_level=max has no thinking budget cap, so the
+   * 16K output ceiling can be fully consumed by thinking, leaving zero tokens
+   * for any visible response. The host treats this as a recovery-worthy
+   * truncation and re-prompts with a no-think-this-turn hint.
+   */
+  notifyTruncation?(detail: { messageId: string; outputTokens: number }): void;
 }
 
 /**
@@ -94,6 +105,26 @@ function bindActiveUserTurn(deps: SessionEventBridgeDeps): string | undefined {
     }
   }
   return entryId;
+}
+
+/**
+ * True iff the assistant message was truncated by `max_tokens` and contains
+ * no actionable content (only thinking). Exported so tests can lock the rule
+ * without a full Pi event stream. Uses weak typing on purpose — the message
+ * shape from Pi may shift across SDK releases; null guards are defensive.
+ */
+export function isTruncatedThinkingOnly(message: unknown): boolean {
+  if (!message || typeof message !== "object") return false;
+  const m = message as { stopReason?: unknown; content?: unknown };
+  if (m.stopReason !== "length") return false;
+  if (!Array.isArray(m.content)) return false;
+  for (const part of m.content) {
+    if (!part || typeof part !== "object") continue;
+    const t = (part as { type?: unknown }).type;
+    if (t === "text" || t === "toolCall") return false;
+  }
+  // length + no text + no toolCall + content array exists → truncation-only
+  return true;
 }
 
 /** Subscribes to `session`'s Pi events and forwards them via `deps`. Returns the unsubscribe function. */
@@ -275,6 +306,20 @@ export function bridgeSessionEvents(
           });
           if (isError && msg.errorMessage) {
             deps.setStatus("error", msg.errorMessage);
+          }
+          // M3 + thinking_level=max 撞墙:output 配额全花光在 thinking,
+          // 留下零 text / 零 tool_call。让 host 决定是否 inject 恢复 prompt。
+          if (!isError && !isAborted && deps.notifyTruncation) {
+            const assistantMsg = event.message as {
+              content?: Array<{ type?: string }>;
+              usage?: { output?: number };
+            };
+            if (isTruncatedThinkingOnly(assistantMsg)) {
+              deps.notifyTruncation({
+                messageId: deps.messageIdFrom(event.message),
+                outputTokens: Number(assistantMsg.usage?.output ?? 0),
+              });
+            }
           }
         }
         break;

--- a/apps/desktop/electron/agent/session-host.ts
+++ b/apps/desktop/electron/agent/session-host.ts
@@ -99,12 +99,46 @@ import {
 export type { ToolDetailRecord } from "./session-host-helpers";
 
 
+/**
+ * Marker prefix for the system-injected recovery prompt. Used by `prompt()` to
+ * tell the recovery-prompt path apart from user-typed prompts, so that
+ * `consecutiveTruncationRetries` only resets when the user types something
+ * (not when the host re-prompts itself).
+ */
+export const TRUNCATION_RECOVERY_MARKER = "[system-recovery]";
+
+/**
+ * Build the one-shot recovery hint injected when an assistant turn was
+ * truncated by `max_tokens` with no text / no tool call. English, ~80 words,
+ * intentionally short so it doesn't itself risk hitting the same cap.
+ */
+export function buildTruncationRecoveryHint(): string {
+  return [
+    TRUNCATION_RECOVERY_MARKER,
+    "Your previous turn was truncated at max_tokens (output budget exhausted by thinking).",
+    "To recover, do not do deep reasoning this turn — emit exactly one tool call now",
+    "(read / grep / edit / run / godot_run_main_scene) to checkpoint progress, then",
+    "read its result, then continue. Save longer thinking for the next turn.",
+  ].join(" ");
+}
+
+
 export class SessionHost {
   private bundle: SessionBundle | null = null;
   private modelRuntime: ModelRuntime | null = null;
   private status: AgentStatus = "idle";
   /** Prevent overlapping model title requests for the same open session. */
   private autoTitleInFlight = false;
+  /**
+   * Consecutive-truncation retry counter. Incremented in `notifyTruncation`
+   * (event-bridge detects `stopReason: "length"` with no actionable content)
+   * and reset to 0 in `prompt()` whenever the text is not a recovery prompt
+   * (i.e. user-typed input). Capped at `MAX_TRUNCATION_RETRIES` — beyond that
+   * the host sets an error status and stops auto-retrying, asking the user
+   * to lower thinking level / switch model.
+   */
+  private consecutiveTruncationRetries = 0;
+  private static readonly MAX_TRUNCATION_RETRIES = 2;
   /**
    * True while prompt() is inside the preparePromptCheckpoint → session.prompt
    * transition (isStreaming is still false there, so a concurrent retract
@@ -525,6 +559,9 @@ export class SessionHost {
       onAgentSettled: () => {
         void this.sessionMode.onAgentSettled();
       },
+      notifyTruncation: (detail) => {
+        void this.notifyTruncation(detail);
+      },
     };
     return bridgeSessionEvents(session, deps);
   }
@@ -788,6 +825,59 @@ export class SessionHost {
     return this.lifecycle.dispose();
   }
 
+  /**
+   * Called by the event-bridge when the assistant message was truncated by
+   * `max_tokens` with no text / no tool call (thinking used all output budget).
+   * Injects a one-shot recovery prompt up to `MAX_TRUNCATION_RETRIES` times
+   * per consecutive truncation streak. On cap, surfaces an error status
+   * asking the user to lower thinking level or switch model — repeated
+   * auto-retry cannot shrink the input context that's the real culprit.
+   *
+   * Recovery prompt is dispatched via `queueMicrotask` so it lands after
+   * the current turn's `turn_end` event, otherwise Pi's `isStreaming` would
+   * still be true and `session.prompt` would steer instead of starting a
+   * fresh turn.
+   */
+  async notifyTruncation(detail: { messageId: string; outputTokens: number }): Promise<void> {
+    if (!this.bundle) {
+      dbgLog("session", "notifyTruncation skipped: no bundle");
+      return;
+    }
+    if (this.consecutiveTruncationRetries >= SessionHost.MAX_TRUNCATION_RETRIES) {
+      dbgLog("session", "notifyTruncation capped", {
+        attempts: this.consecutiveTruncationRetries,
+        messageId: detail.messageId,
+      });
+      this.setStatus(
+        "error",
+        `已自动重试 ${SessionHost.MAX_TRUNCATION_RETRIES} 次仍被 max_tokens 截断。请把设置里的 thinking 改为 off 或换 M2.7。`,
+      );
+      return;
+    }
+    this.consecutiveTruncationRetries += 1;
+    dbgLog("session", "notifyTruncation: scheduling retry", {
+      attempt: this.consecutiveTruncationRetries,
+      messageId: detail.messageId,
+      outputTokens: detail.outputTokens,
+    });
+    this.setStatus("retrying", "上一轮被 max_tokens 截断,正在自动重试…");
+    // Defer until after turn_end so the new turn starts cleanly.
+    queueMicrotask(() => {
+      const bundle = this.bundle;
+      if (!bundle) {
+        dbgLog("session", "notifyTruncation deferred call: bundle gone");
+        return;
+      }
+      void this.prompt({ text: buildTruncationRecoveryHint() }).catch((err) => {
+        dbgWarn(
+          "session",
+          "notifyTruncation prompt failed",
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+    });
+  }
+
   async prompt(payload: PromptPayload): Promise<PromptResult> {
     const bundle = this.bundle;
     if (!bundle) {
@@ -799,6 +889,12 @@ export class SessionHost {
     if (!text && (!images || images.length === 0)) {
       dbgLog("session", "prompt rejected: empty text and no images");
       return { ok: false, error: "消息不能为空" };
+    }
+    // User-typed prompt → reset truncation retry counter. Recovery prompts
+    // (system-injected via notifyTruncation) carry the marker; everything
+    // else (including extension commands) is treated as user input.
+    if (!text.startsWith(TRUNCATION_RECOVERY_MARKER)) {
+      this.consecutiveTruncationRetries = 0;
     }
 
     dbgLog("session", "prompt start", {

--- a/apps/desktop/electron/agent/session-mode/controller.ts
+++ b/apps/desktop/electron/agent/session-mode/controller.ts
@@ -53,6 +53,7 @@ import {
 } from "./plan-journal";
 import {
   buildAskModeSystemAppend,
+  buildCompletionDisciplineAppend,
   buildGameDesignLayoutGuide,
   buildGoalModeSystemAppend,
   buildPlanModeSystemAppend,
@@ -149,6 +150,10 @@ export class SessionModeController {
     // independent reads. Applies to every session type because the
     // 195k-context blowup is just as easy to hit in code sessions.
     out.push(buildToolEconomyAppend());
+    // Completion discipline — when to stop. Universal across all modes
+    // because Agent mode has no mode-specific append, and even Ask/Plan/Goal
+    // benefit from the explicit "verify before claiming done" rule.
+    out.push(buildCompletionDisciplineAppend());
     if (this.agentMode === "ask") {
       out.push(buildAskModeSystemAppend());
     } else if (this.agentMode === "plan") {

--- a/apps/desktop/shared/mode-prompt.test.ts
+++ b/apps/desktop/shared/mode-prompt.test.ts
@@ -39,9 +39,10 @@ describe("mode-prompt instructions", () => {
     expect(GOAL_MODE_INSTRUCTIONS).toContain("verifiable evidence");
   });
 
-  it("Completion discipline 覆盖 5 条核心规则(verify / multi-part / blocked / continue / verification step)", () => {
+  it("Completion discipline 覆盖 6 条核心规则(verify / multi-part / blocked / continue / verification step / thinking-budget checkpoint)", () => {
     // 锁住根因:Agent 模式原本空,导致模型改 1 处就 end_turn。
-    // 5 条规则见 mode-prompt.ts COMPLETION_DISCIPLINE_INSTRUCTIONS 注释。
+    // 第 6 条 (2026-09-01 #user-report) 解决 M3 + thinking_level=max 把 output 配额
+    // 全部花在 thinking 上、留下空 response 的特定问题。
     expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(/verify/i);
     expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(
       /multiple parts|numbered list|several sub-asks/i,
@@ -50,6 +51,13 @@ describe("mode-prompt instructions", () => {
     expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(/continu/i);
     expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(
       /verification|test|build|lint|simulation|grep/i,
+    );
+    // 第 6 条:thinking budget checkpoint
+    expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(
+      /output budget|max_tokens|truncated/i,
+    );
+    expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(
+      /emit(ing|s| a tool call)?|tool call|checkpoint/i,
     );
   });
 });
@@ -66,12 +74,13 @@ describe("mode-prompt builders", () => {
     expect(out).toContain("GOAL CONDITION: all tests pass");
   });
 
-  it("buildCompletionDisciplineAppend 带标题 + 长度 < 800 字符(防膨胀)", () => {
+  it("buildCompletionDisciplineAppend 带标题 + 长度 < 1000 字符(防膨胀)", () => {
     const out = buildCompletionDisciplineAppend();
     expect(out.startsWith("# X-agent Completion discipline")).toBe(true);
     expect(out).toContain(COMPLETION_DISCIPLINE_INSTRUCTIONS);
-    // 800 是缓存键稳定性预算:再长会让 system prompt 每次变更都重置缓存。
-    expect(out.length).toBeLessThan(800);
+    // 1000 是缓存键稳定性预算:再长会让 system prompt 每次变更都重置缓存。
+    // 6 条规则完整后约 950 字符;新规则需要时可挤到 990 仍安全。
+    expect(out.length).toBeLessThan(1000);
   });
 });
 

--- a/apps/desktop/shared/mode-prompt.test.ts
+++ b/apps/desktop/shared/mode-prompt.test.ts
@@ -8,11 +8,13 @@ import {
   PLAN_MODE_INSTRUCTIONS,
   GOAL_MODE_INSTRUCTIONS,
   DESIGN_SESSION_TYPE_INSTRUCTIONS,
+  COMPLETION_DISCIPLINE_INSTRUCTIONS,
   buildAskModeSystemAppend,
   buildPlanModeSystemAppend,
   buildGoalModeSystemAppend,
   buildDesignSessionTypeAppend,
   buildGameDesignLayoutGuide,
+  buildCompletionDisciplineAppend,
   wrapWithModeBlock,
   stripModeBlocks,
   modeBlockLabel,
@@ -36,6 +38,20 @@ describe("mode-prompt instructions", () => {
   it("Goal 指令要求可验证证据", () => {
     expect(GOAL_MODE_INSTRUCTIONS).toContain("verifiable evidence");
   });
+
+  it("Completion discipline 覆盖 5 条核心规则(verify / multi-part / blocked / continue / verification step)", () => {
+    // 锁住根因:Agent 模式原本空,导致模型改 1 处就 end_turn。
+    // 5 条规则见 mode-prompt.ts COMPLETION_DISCIPLINE_INSTRUCTIONS 注释。
+    expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(/verify/i);
+    expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(
+      /multiple parts|numbered list|several sub-asks/i,
+    );
+    expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(/blocker|blocked/i);
+    expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(/continu/i);
+    expect(COMPLETION_DISCIPLINE_INSTRUCTIONS).toMatch(
+      /verification|test|build|lint|simulation|grep/i,
+    );
+  });
 });
 
 describe("mode-prompt builders", () => {
@@ -48,6 +64,14 @@ describe("mode-prompt builders", () => {
   it("buildGoalModeSystemAppend 注入条件", () => {
     const out = buildGoalModeSystemAppend("all tests pass");
     expect(out).toContain("GOAL CONDITION: all tests pass");
+  });
+
+  it("buildCompletionDisciplineAppend 带标题 + 长度 < 800 字符(防膨胀)", () => {
+    const out = buildCompletionDisciplineAppend();
+    expect(out.startsWith("# X-agent Completion discipline")).toBe(true);
+    expect(out).toContain(COMPLETION_DISCIPLINE_INSTRUCTIONS);
+    // 800 是缓存键稳定性预算:再长会让 system prompt 每次变更都重置缓存。
+    expect(out.length).toBeLessThan(800);
   });
 });
 

--- a/apps/desktop/shared/mode-prompt.ts
+++ b/apps/desktop/shared/mode-prompt.ts
@@ -106,6 +106,29 @@ export function buildToolEconomyAppend(): string {
 }
 
 /**
+ * Completion discipline — when to stop, when to keep going. Injected for every
+ * session type and every mode (Agent / Ask / Plan / Goal) because the
+ * underlying issue is universal: MiniMax-M3 (and any LLM leaning concise)
+ * ends the turn after a small edit without verifying the change actually
+ * addressed the user's request. Goal mode has a stronger version of this
+ * rule, but Ask / Agent / Plan need it too. Sits after `Tool economy` and
+ * before the mode-specific append, so the order is "how to work" → "when to
+ * stop" → "mode-specific shape". Keep this short and durable; updating the
+ * string bumps the system-prompt cache key for every active session.
+ */
+export const COMPLETION_DISCIPLINE_INSTRUCTIONS = [
+  "Before ending the turn, verify the user's request is actually complete — not just plausible from reading code.",
+  "If you made changes, run a verification step (test, build, lint, simulation, or grep on the changed file) and report the actual output.",
+  "If the request has multiple parts (numbered list, several sub-asks), address each part and confirm each before saying 'done'.",
+  "If a step is blocked, name the blocker explicitly and what you tried — do not declare 'done' on a partial solution.",
+  "Default to continuing the same task in the same turn when more steps remain, instead of stopping for the user to say 'continue'.",
+].join("\n");
+
+export function buildCompletionDisciplineAppend(): string {
+  return ["# X-agent Completion discipline", COMPLETION_DISCIPLINE_INSTRUCTIONS].join("\n");
+}
+
+/**
  * GDD 布局引导 —— 给"整理/写入设计文档"任务列标准子模块。
  * 由 controller.composeModeAppend 在 design session 追加在 type append 之后。
  *

--- a/apps/desktop/shared/mode-prompt.ts
+++ b/apps/desktop/shared/mode-prompt.ts
@@ -122,6 +122,7 @@ export const COMPLETION_DISCIPLINE_INSTRUCTIONS = [
   "If the request has multiple parts (numbered list, several sub-asks), address each part and confirm each before saying 'done'.",
   "If a step is blocked, name the blocker explicitly and what you tried — do not declare 'done' on a partial solution.",
   "Default to continuing the same task in the same turn when more steps remain, instead of stopping for the user to say 'continue'.",
+  "Long unbroken thinking can exhaust your output budget (max_tokens), leaving the turn truncated with no text or tool call. If you have been reasoning for a while without emitting one, stop and emit a tool call (read / grep / edit / run) to checkpoint. The next turn continues from your tool results, not from your thoughts.",
 ].join("\n");
 
 export function buildCompletionDisciplineAppend(): string {


### PR DESCRIPTION
## 概要

修复 X-agent + M3 模型下用户「对话没做完就停」的两类根因——LLM 提前 end_turn(系统 prompt 没纪律)以及 LLM thinking 用光 output 预算留下空 response(Pi 自身无解)。本 PR 用 3 个 commit 在 system append / 主进程检测 / 自动 retry 三个层面逐级收紧,从「软提醒 LLM」到「X-agent 主进程兜底」。

## 改动

**3 commit / 6 文件 / +429 行**

- `79e0395` fix(agent): 加 completion discipline system append 减少模型提前 stop
- `cce1428` fix(agent): completion discipline 第 6 条防 thinking 用光 output budget
- `08efa96` fix(agent): 检测 max_tokens 截断并自动 retry 防止 thinking 用光 output budget

## 根因

| # | 症状 | 根因 | 修复层 |
|---|---|---|---|
| 1 | LLM 改完文件 end_turn,工作没做完 | Agent 模式无 system append,默认 system prompt 不强制"verify before done" | system prompt:6 条 completion discipline(commit 1 + 2) |
| 2 | LLM thinking 用光 16K output 配额,留下空 response(stopReason="length") | M3 + thinking_level=max 启用 `thinking: {type:"adaptive"}` 无 budget cap;Pi 只能在 message_end 报 stopReason,无法在 thinking 流中插话 | 主进程检测 + 自动 retry(commit 3) |

## 关键设计

### Commit 1+2: completion discipline

`apps/desktop/shared/mode-prompt.ts` 新增 `COMPLETION_DISCIPLINE_INSTRUCTIONS` + `buildCompletionDisciplineAppend()`,共 6 条规则:

1. end turn 前先验证
2. 改完跑一次验证(test/build/lint/simulation/grep)
3. 多步任务逐项 verify
4. 阻塞要说清楚
5. 不要中途空停
6. thinking 接近 output 预算上限就 emit tool_call 防止撞墙

`controller.ts#composeModeAppend` 在 tool economy 之后、mode-specific append 之前注入。`mode-prompt.test.ts` 加 1 case 锁住 6 条 + 字符预算 < 1000。

### Commit 3: max_tokens 自动 retry

`apps/desktop/electron/agent/session-event-bridge.ts`:
- 新增 `isTruncatedThinkingOnly(message)` 纯函数:stopReason="length" + content 无 text/toolCall → true
- `SessionEventBridgeDeps.notifyTruncation?(detail)` optional callback,向后兼容老 host
- `message_end` (assistant) 路径加 detection 调用

`apps/desktop/electron/agent/session-host.ts`:
- `TRUNCATION_RECOVERY_MARKER` ("[system-recovery]") + `buildTruncationRecoveryHint()` 顶层 export
- `consecutiveTruncationRetries` 字段 + `MAX_TRUNCATION_RETRIES = 2` cap
- `notifyTruncation(detail)` 方法:cap 检查 → setStatus("retrying") → queueMicrotask 推迟到 turn_end 之后 → 调 this.prompt(retry hint)
- `prompt()` 顶部:text 不以 marker 开头 → counter 重置(用户主动 prompt 清零)
- `bridgeEvents` deps 注入 notifyTruncation callback

`apps/desktop/electron/agent/session-event-bridge.test.ts`(新):
- 6 case for isTruncatedThinkingOnly(length+only thinking → true;含 text → false;含 toolCall → false;stop+only thinking → false;length+空 content → true;null/非对象 → false)
- 3 case for bridge integration(length+only thinking → notifyTruncation 被调;stop → 不调;notifyTruncation 未注入时不抛错,assistant_end 正常 emit)

### Retry hint(英文,~80 词)

> "[system-recovery] Your previous turn was truncated at max_tokens (output budget exhausted by thinking). To recover, do not do deep reasoning this turn — emit exactly one tool call now (read / grep / edit / run / godot_run_main_scene) to checkpoint progress, then read its result, then continue. Save longer thinking for the next turn."

## UI 行为(无需改 renderer)

- 自动 retry 时聊天面板出现 `[system-recovery]` 开头 user 气泡(Pi 自然 emit user_message)
- 顶栏 status 切 `retrying`
- 连续 2 次仍撞墙 → setStatus("error", "已重试 2 次仍撞,请把 thinking 改为 off 或换 M2.7") 不再 retry
- 任何用户主动 prompt → counter 立即重置

## 验证

- `npm run test:unit`: 48 文件 618 用例全过(11.5s;上轮 609 + 本轮 9)
- `npm run typecheck`: exit 0
- `session-event-bridge.test.ts`: 9/9(6 detection + 3 integration)
- `mode-prompt.test.ts`: 18/18(6 条规则全保)

## 已知边界(plan §七 风险)

- **queueMicrotask 时序**:需真实跑通确认 `turn_end` 真的先于 microtask;若否切 `setTimeout(0)`
- **MAX_RETRY=2 不可调**:hard-code;后续可加 `prefs.maxTruncationRetries`
- **Pacing 提醒**(thinking_delta 累计 N token 还没 tool call 就注入 hint)与本机制正交,可独立加
- **完成 checklist**(用户说 done 必须 verify)与本机制正交,可独立加
- **系统 prompt 不能 100% 强制模型**:第 1、2 commit 是软提醒;第 3 commit 是硬基建兜底
- **doc:drift 工具不在本分支**(在 #82 / `docs/overall-doc-update-2026-09` 分支);如要同步可 cherry-pick `40d5152`

## 影响面

- 仅 `apps/desktop/electron/agent/` 与 `apps/desktop/shared/` 下文件
- 零 schema 变更 / 零运行时破坏 / 零 renderer 改动
- 新增 `assistant_end` 之外的轻量 user_message 事件流(自然触发,无新 event type)
- `notifyTruncation?` 在 deps 接口是 optional,老 host 不传也不挂

## 回滚

`git revert <commit>` 即可,无 schema / 持久化 / 行为破坏(只是 system append 变回去、retry 机制去掉)。
