### PR TITLE
release: v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@ CHANGELOG 是**用户面向**的 release notes，不是 commit log，也不是�
 
 实现细节（路径解析规则、sidecar 格式、工具白名单、vitest 覆盖）都进 PR 描述与 commit，CHANGELOG 只承担"用户能看到什么"。
 
-## Unreleased
+## 0.6.2
 
 ### 改进
 
+- **供应商模型加支持图片开关**：「设置 → 供应商 → 编辑」模型行新增 `text` / `image` 多选 chip；勾上 image 后，OpenAI 兼容 / 自建网关也能正常发图，Pi SDK `mistral-conversations` 等 adapter 不再把 user message 含 image 的整条消息替换为 `(image omitted)` 占位文本。
 - **/init 命令 + AGENT.md 自动加载**：composer `/` 菜单新增 `init` 命令，为当前项目一键生成根目录 AGENTS.md（已有时按 Mavis init 流程停下询问 skip / overwrite with backup / show diff，绝不绕过用户确认覆盖）；项目根的 `AGENT.md` / `agent.md` 单数变体自动并入模型上下文，与现有 `AGENTS.md` / `CLAUDE.md` 共存不冲突。
 - **Slash 命令走 `<cmd>` chip 渲染**：`/init` 等 Pi extension command 在 user bubble 渲染为可折叠的 `<cmd name="…">` chip（与 `<skill>` / `<prompt>` / `<file>` 同型），不再把整个 bootstrap body 作为 raw markdown 灌进 user bubble。
 - **清理未引用的代码与类型声明**：移除全仓零引用的 9 个 export（含 4 个 godot-rpc 类型别名、`isDebugMode` / `isSkipPiSyncForTests` / `isGodotPiPackageInstalled` / `gitDownloadUrl` / `IpcEventChannel`），以及与 vite/client 重复的 `src/assets/png.d.ts`。无用户可见行为变化。

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "x-agent-desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "x-agent-desktop",
-      "version": "0.6.1",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "@earendil-works/pi-coding-agent": "^0.84.4",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-agent-desktop",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Pi Agent desktop client (X-agent)",
   "license": "MIT",
   "author": {


### PR DESCRIPTION
# Release v0.6.2

按 CLAUDE.md §7 发版流程: 整理 CHANGELOG + `npm run release:prepare -- 0.6.2` + release PR。

## 改动

- `apps/desktop/package.json` version: 0.6.1 → 0.6.2
- `apps/desktop/package-lock.json` 同步
- `CHANGELOG.md` 新建 `## 0.6.2` 章节, 4 条改进:
  - 供应商模型加支持图片开关 (PR #93, text / image 多选 chip, 透传 Pi models.json, 根因解 `mistral-conversations` adapter 的 `(image omitted)` 占位替换)
  - /init 命令 + AGENT.md 自动加载
  - Slash 命令走 `<cmd>` chip 渲染
  - 清理未引用的代码与类型声明

## 验证

- [x] `npm run release:prepare -- 0.6.2` 通过
- [x] `npm run desktop:typecheck` 通过
- [x] `npm test` 通过
- [x] `npx vitest run` 46 个相关用例全过
- [x] CHANGELOG 抽取 (`npm run release:notes -- 0.6.2`) 与章节内容一致
- [ ] `npm run desktop:dist` 本地 Windows exe 冒烟 — 可选, CI 仍会重建 (本机产物不入 git)

## 合并后

1. 合并到 master
2. `git tag v0.6.2 && git push origin v0.6.2` (master HEAD)
3. 触发 `.github/workflows/release.yml` 自动 typecheck + lint + test + electron-builder + 上传 GitHub Release
4. GitHub Release 正文由 `scripts/extract-changelog.mjs` 从 `## 0.6.2` 章节抽取

## 关联

- Closes 之前 master 上一段「`## Unreleased` 3 条积压 + PR #93」一次清账
- 0.6.1 tag 在历史 commit `27efb65` 已存在, 本地之前漏 tag, 已在本次 release PR 之前补 push