### PR TITLE
chore(agent): sync CLAUDE.md Dependabot note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ X-agent 是基于 Pi SDK 的 Electron 桌面 Agent。仓库只有一个实际应
 
 - [`.github/workflows/ci.yml`](.github/workflows/ci.yml) 监听 push / PR,三 job 并行
 - `concurrency: cancel-in-progress: true`(同 ref 旧运行自动取消)
-- 失败必须修;依赖更新暂不启用 Dependabot(避免噪音),改用 `npm outdated` 季度手工检查
+- 失败必须修;依赖更新走 Dependabot(配置见 [`.github/dependabot.yml`](.github/dependabot.yml),细节见 §9),季度再 `npm outdated` 复核
 - [`.github/workflows/release.yml`](.github/workflows/release.yml) 仅在 tag push / workflow_dispatch 触发,见 §7
 
 ### 7. 发版流程


### PR DESCRIPTION
## Summary
- Sync `CLAUDE.md` section 6 wording with current state: Dependabot **is** enabled in this repo (`.github/dependabot.yml` runs every Monday morning, and recent PRs #92 / #90 / #89 / #86 have been squash-merged). The old line "???? Dependabot" was inconsistent with section 9 and with reality.
- Replace it with "????? Dependabot (config in `.github/dependabot.yml`, details in section 9), ??? `npm outdated` ??", and cross-reference section 9 for the full description.
- Side cleanup (done on GitHub, not in this PR): #4 / #15 closed as wontfix; #1 / #2 / #3 got a `Refs ?? A-J` anchor in their bodies.

## Why
Dependabot PRs (#92 / #90 / #89 / #86 / ...) have been merged continuously; the old "????" wording misleads future collaborators and contradicts section 9 ("??????:`.github/dependabot.yml`").

## Test
- 1-line doc change, typecheck / lint / unit / e2e not affected.

## Risk
- 0 risk, pure wording.

## Rollback
- `git revert` (or `git push origin :chore/issue-cleanup-2026-09-08`).
