### PR TITLE
feat(security): handler throw 翻译 + debug-log secret redact + 5 个核心 vitest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ apps/desktop/**/playwright-report
 apps/desktop/coverage
 # Local repro pages and build reports
 .scratch/
+
+# Stale agent worktree checkouts (not registered git worktrees, drift cruft)
+.worktrees/
+

--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -9,3 +9,10 @@ release
 
 # TypeScript build info cache
 *.tsbuildinfo
+
+# TypeScript declaration emit artifacts (composite mode without outDir)
+**/*.d.ts
+
+# TypeScript JavaScript emit artifacts (composite mode without outDir)
+**/*.js.map
+**/*.js

--- a/apps/desktop/electron/agent/pi-settings.test.ts
+++ b/apps/desktop/electron/agent/pi-settings.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Vitest unit test for `electron/agent/pi-settings` (read-modify-write atomically).
+ *
+ * Why it matters: `~/.pi/agent/settings.json` is shared with the Pi CLI and
+ * written by both X-agent (bash shellPath, package sources) and Pi itself.
+ * We must (1) preserve every other field the other writer puts there, (2) keep
+ * the on-disk file atomic so a crash mid-write can never truncate the previous
+ * good copy, and (3) recover from a corrupt file rather than crash the app.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  piSettingsPath,
+  mutatePiSettingsSync,
+  readPiSettingsSync,
+} from "./pi-settings";
+import { setAgentDirOverrideForTests } from "./prefs";
+
+describe("pi-settings (atomic read-modify-write of ~/.pi/agent/settings.json)", () => {
+  let tempDir: string;
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "x-agent-pi-settings-"));
+    setAgentDirOverrideForTests(tempDir);
+  });
+  afterEach(() => {
+    setAgentDirOverrideForTests(null);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("piSettingsPath() resolves to <agentDir>/settings.json", () => {
+    expect(piSettingsPath()).toBe(join(tempDir, "settings.json"));
+  });
+
+  it("first mutate creates the file with the patched content", () => {
+    expect(existsSync(piSettingsPath())).toBe(false);
+    mutatePiSettingsSync((s) => {
+      s.shellPath = "/usr/bin/bash";
+    });
+    expect(existsSync(piSettingsPath())).toBe(true);
+    expect(readPiSettingsSync()).toEqual({ shellPath: "/usr/bin/bash" });
+  });
+
+  it("subsequent mutates preserve fields written by previous mutates (no clobber)", () => {
+    mutatePiSettingsSync((s) => {
+      s.shellPath = "/bin/bash";
+    });
+    mutatePiSettingsSync((s) => {
+      s.packageSources = ["npm:foo"];
+    });
+    const final = readPiSettingsSync();
+    expect(final.shellPath).toBe("/bin/bash");
+    expect(final.packageSources).toEqual(["npm:foo"]);
+  });
+
+  it("corrupted JSON file → mutate recovers without throwing", () => {
+    writeFileSync(piSettingsPath(), "{not valid json", "utf8");
+    mutatePiSettingsSync((s) => {
+      s.shellPath = "/usr/bin/zsh";
+    });
+    expect(readPiSettingsSync()).toEqual({ shellPath: "/usr/bin/zsh" });
+  });
+
+  it("non-object JSON root (array) → mutate replaces with fresh object", () => {
+    writeFileSync(piSettingsPath(), "[1,2,3]", "utf8");
+    mutatePiSettingsSync((s) => {
+      s.shellPath = "/bin/sh";
+    });
+    expect(readPiSettingsSync()).toEqual({ shellPath: "/bin/sh" });
+  });
+
+  it("no .tmp sibling left behind after a successful mutate", () => {
+    mutatePiSettingsSync((s) => {
+      s.x = 1;
+    });
+    const siblings = readdirSync(tempDir).filter((f) => f.endsWith(".tmp"));
+    expect(siblings).toEqual([]);
+  });
+
+  it("concurrent mutates from the same JS tick serialize via atomic rename", () => {
+    // Same lock invariant as the real path: two reads-then-writes in the same
+    // microtask must both persist (no overwrite). JS is single-threaded so this
+    // is a happy-path sanity check, not a race detector.
+    mutatePiSettingsSync((s) => {
+      s.a = "first";
+    });
+    mutatePiSettingsSync((s) => {
+      s.b = "second";
+    });
+    expect(readPiSettingsSync()).toEqual({ a: "first", b: "second" });
+  });
+});

--- a/apps/desktop/electron/agent/session-mode/plan-mode-guard.test.ts
+++ b/apps/desktop/electron/agent/session-mode/plan-mode-guard.test.ts
@@ -1,0 +1,243 @@
+/**
+ * Vitest unit test for `electron/agent/session-mode/plan-mode-guard`.
+ *
+ * Hard-gate the Ask / Plan modes' tool surface:
+ *  - Agent mode: never blocks (the only mode allowed to mutate state).
+ *  - Ask / Plan: only read tools and write_plan; bash must pass the read-only
+ *    classifier AND stay inside the project cwd; read/grep/find/ls must keep
+ *    their `path` argument inside cwd or a plugin-readable root.
+ */
+import { describe, it, expect } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  shouldBlockReadonlyModeToolCall,
+  createPlanModeGuardExtension,
+} from "./plan-mode-guard";
+
+describe("shouldBlockReadonlyModeToolCall (Ask/Plan hard gate)", () => {
+  describe("mode gating", () => {
+    it("agent mode never blocks any tool", () => {
+      expect(
+        shouldBlockReadonlyModeToolCall(
+          "agent",
+          "write",
+          ["write", "bash"],
+          { path: "/tmp/foo" },
+          "/tmp",
+        ).block,
+      ).toBe(false);
+      expect(
+        shouldBlockReadonlyModeToolCall(
+          "agent",
+          "bash",
+          ["bash"],
+          { command: "rm -rf /" },
+          "/tmp",
+        ).block,
+      ).toBe(false);
+    });
+
+    it("ask + tool in allowlist → not blocked", () => {
+      expect(
+        shouldBlockReadonlyModeToolCall(
+          "ask",
+          "read",
+          ["read"],
+          { path: "src/index.ts" },
+          "/tmp",
+        ).block,
+      ).toBe(false);
+    });
+
+    it("plan + tool not in allowlist → blocked with plan-mode message", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "plan",
+        "write",
+        ["read", "write_plan"],
+        { path: "src/index.ts" },
+        "/tmp",
+      );
+      expect(r.block).toBe(true);
+      expect(r.reason).toMatch(/Plan 模式/);
+    });
+
+    it("ask + tool not in allowlist → blocked with ask-mode message", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "edit",
+        ["read"],
+        { path: "src/index.ts" },
+        "/tmp",
+      );
+      expect(r.block).toBe(true);
+      expect(r.reason).toMatch(/调研模式/);
+    });
+  });
+
+  describe("bash gating", () => {
+    it("ask + bash not in allowlist → blocked", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "bash",
+        ["read"],
+        { command: "ls" },
+        "/tmp",
+      );
+      expect(r.block).toBe(true);
+      expect(r.reason).toMatch(/调研模式/);
+    });
+
+    it("ask + bash in allowlist + readonly cmd → not blocked (cwd inside)", () => {
+      const cwd = mkdtempSync(join(tmpdir(), "x-agent-pmg-"));
+      expect(
+        shouldBlockReadonlyModeToolCall(
+          "ask",
+          "bash",
+          ["bash"],
+          { command: "ls" },
+          cwd,
+        ).block,
+      ).toBe(false);
+    });
+
+    it("ask + bash non-readonly cmd → blocked", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "bash",
+        ["bash"],
+        { command: "rm -rf /" },
+        "/tmp",
+      );
+      expect(r.block).toBe(true);
+      expect(r.reason).toBeTruthy();
+    });
+
+    it("ask + bash readonly cmd but escapes cwd → blocked", () => {
+      const cwd = mkdtempSync(join(tmpdir(), "x-agent-pmg-cwd-"));
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "bash",
+        ["bash"],
+        { command: "cat /etc/passwd" },
+        cwd,
+      );
+      expect(r.block).toBe(true);
+    });
+
+    it("ask + bash without cwd → readonly cmd allowed (cwd check skipped)", () => {
+      expect(
+        shouldBlockReadonlyModeToolCall(
+          "ask",
+          "bash",
+          ["bash"],
+          { command: "ls" },
+        ).block,
+      ).toBe(false);
+    });
+  });
+
+  describe("path-tool gating (read/grep/find/ls)", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "x-agent-pmg-paths-"));
+
+    it("path escaping cwd via `..` → blocked", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "read",
+        ["read"],
+        { path: "../outside.ts" },
+        cwd,
+      );
+      expect(r.block).toBe(true);
+      expect(r.reason).toMatch(/调研\/Plan 模式禁止/);
+    });
+
+    it("path inside cwd → not blocked", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "grep",
+        ["grep"],
+        { path: "src/index.ts" },
+        cwd,
+      );
+      expect(r.block).toBe(false);
+    });
+
+    it("absolute path outside cwd → blocked", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "plan",
+        "find",
+        ["find"],
+        { path: "C:\\Windows\\System32" },
+        cwd,
+      );
+      expect(r.block).toBe(true);
+    });
+
+    it("path with `~` expansion to home is blocked when home is not a plugin root", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "read",
+        ["read"],
+        { path: "~/.ssh/id_rsa" },
+        cwd,
+      );
+      expect(r.block).toBe(true);
+    });
+
+    it("non-string path → blocked", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "read",
+        ["read"],
+        { path: 42 },
+        cwd,
+      );
+      expect(r.block).toBe(true);
+    });
+
+    it("missing path arg → not blocked (default = cwd itself)", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "read",
+        ["read"],
+        {},
+        cwd,
+      );
+      expect(r.block).toBe(false);
+    });
+
+    it("godot_detect_project path-tool is covered by the same gate", () => {
+      const r = shouldBlockReadonlyModeToolCall(
+        "ask",
+        "godot_detect_project",
+        ["godot_detect_project"],
+        { path: "../escape" },
+        cwd,
+      );
+      expect(r.block).toBe(true);
+    });
+  });
+});
+
+describe("createPlanModeGuardExtension (InlineExtension factory)", () => {
+  it("returns an InlineExtension-shaped callable", () => {
+    const ext = createPlanModeGuardExtension({
+      getMode: () => "ask",
+      getAllowedTools: () => ["read"],
+      getCwd: () => "/tmp",
+    });
+    expect(typeof ext).toBe("function");
+  });
+
+  it("the returned extension does not throw on construction", () => {
+    expect(() =>
+      createPlanModeGuardExtension({
+        getMode: () => "plan",
+        getAllowedTools: () => ["bash"],
+        getCwd: () => "/tmp",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/apps/desktop/electron/agent/session-mode/plan-mode-guard.test.ts
+++ b/apps/desktop/electron/agent/session-mode/plan-mode-guard.test.ts
@@ -40,13 +40,17 @@ describe("shouldBlockReadonlyModeToolCall (Ask/Plan hard gate)", () => {
     });
 
     it("ask + tool in allowlist → not blocked", () => {
+      // cwd must be a real existing directory; otherwise resolveInsideCwd
+      // fails at existsSync(cwd) and blocks before reaching the allowedTools
+      // check. CI windows-latest has no Git Bash /tmp mapping; use mkdtempSync.
+      const cwd = mkdtempSync(join(tmpdir(), "x-agent-pmg-mode-"));
       expect(
         shouldBlockReadonlyModeToolCall(
           "ask",
           "read",
           ["read"],
           { path: "src/index.ts" },
-          "/tmp",
+          cwd,
         ).block,
       ).toBe(false);
     });

--- a/apps/desktop/electron/agent/shadow-git.test.ts
+++ b/apps/desktop/electron/agent/shadow-git.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Vitest unit test for `electron/agent/shadow-git`.
+ *
+ * Three layers:
+ *  1. Pure functions (no fs, no git): getCheckpointsRoot / projectKeyForCwd /
+ *     shadowGitDirForCwd / relFromCwd / NESTED_GIT_DISABLED_SUFFIX /
+ *     DEFAULT_SHADOW_EXCLUDES / SHADOW_DIFF_TEXT_MAX_BYTES.
+ *  2. Filesystem-touching helpers (need a temp dir but no git): findNestedGitEntries,
+ *     recoverDisabledNestedGit / recoverAllDisabledNestedGit.
+ *  3. Git-dependent operations: ShadowGit class (commit / diff / restore).
+ *     Skipped when git is unavailable (e.g. minimal CI runner without Git for
+ *     Windows), matching the shadow-checkpoints pattern.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, sep } from "node:path";
+import { execSync } from "node:child_process";
+import {
+  NESTED_GIT_DISABLED_SUFFIX,
+  DEFAULT_SHADOW_EXCLUDES,
+  SHADOW_DIFF_TEXT_MAX_BYTES,
+  getCheckpointsRoot,
+  projectKeyForCwd,
+  shadowGitDirForCwd,
+  relFromCwd,
+  findNestedGitEntries,
+  recoverDisabledNestedGit,
+  recoverAllDisabledNestedGit,
+  ShadowGit,
+} from "./shadow-git";
+
+function gitAvailable(): boolean {
+  try {
+    execSync("git --version", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("shadow-git constants", () => {
+  it("NESTED_GIT_DISABLED_SUFFIX marks disabled nested .git dirs", () => {
+    expect(NESTED_GIT_DISABLED_SUFFIX).toBe(".__xagent_shadow__");
+  });
+
+  it("DEFAULT_SHADOW_EXCLUDES mirrors the shadow-git exclude baseline", () => {
+    expect(DEFAULT_SHADOW_EXCLUDES).toContain(".git/");
+    expect(DEFAULT_SHADOW_EXCLUDES).toContain(`.git${NESTED_GIT_DISABLED_SUFFIX}/`);
+    expect(DEFAULT_SHADOW_EXCLUDES).toContain("node_modules/");
+  });
+
+  it("SHADOW_DIFF_TEXT_MAX_BYTES is the published cap", () => {
+    expect(SHADOW_DIFF_TEXT_MAX_BYTES).toBe(256 * 1024);
+  });
+});
+
+describe("shadow-git pure helpers", () => {
+  it("projectKeyForCwd hashes the cwd to a stable opaque key", () => {
+    const k1 = projectKeyForCwd("/tmp/foo");
+    const k2 = projectKeyForCwd("/tmp/foo");
+    expect(k1).toBe(k2);
+    expect(projectKeyForCwd("/tmp/bar")).not.toBe(k1);
+    expect(k1).toMatch(/^[a-f0-9]{16}$/);
+  });
+
+  it("shadowGitDirForCwd nests the key under the checkpoints root", () => {
+    const dir = shadowGitDirForCwd("/tmp/foo");
+    expect(dir).toBe(join(getCheckpointsRoot(), projectKeyForCwd("/tmp/foo")));
+  });
+
+  it("getCheckpointsRoot is a non-empty absolute-looking string", () => {
+    const root = getCheckpointsRoot();
+    expect(typeof root).toBe("string");
+    expect(root.length).toBeGreaterThan(0);
+  });
+
+  it("relFromCwd returns cwd-relative path for an absolute child", () => {
+    const cwd = "/tmp/proj";
+    const abs = "/tmp/proj/src/index.ts";
+    const r = relFromCwd(cwd, abs);
+    expect(r.startsWith("src")).toBe(true);
+  });
+
+  it("relFromCwd returns empty string when path equals cwd", () => {
+    expect(relFromCwd("/tmp/proj", "/tmp/proj")).toBe("");
+  });
+});
+
+describe("shadow-git fs helpers (no git required)", () => {
+  let work: string;
+  beforeEach(() => {
+    work = mkdtempSync(join(tmpdir(), "x-agent-shadow-git-"));
+  });
+  afterEach(() => {
+    rmSync(work, { recursive: true, force: true });
+  });
+
+  it("findNestedGitEntries returns empty for a dir with no .git", () => {
+    expect(findNestedGitEntries(work)).toEqual([]);
+  });
+
+  it("findNestedGitEntries lists active .git dirs but skips disabled-suffix dirs", () => {
+    mkdirSync(join(work, "sub", ".git"), { recursive: true });
+    mkdirSync(join(work, "sub2", `.git${NESTED_GIT_DISABLED_SUFFIX}`), {
+      recursive: true,
+    });
+    const found = findNestedGitEntries(work);
+    expect(found.length).toBe(1);
+    expect(found[0].endsWith(sep + "sub" + sep + ".git")).toBe(true);
+  });
+
+  it("recoverDisabledNestedGit restores disabled .git dirs to .git", () => {
+    const disabled = join(work, "sub", `.git${NESTED_GIT_DISABLED_SUFFIX}`);
+    mkdirSync(disabled, { recursive: true });
+    writeFileSync(join(disabled, "HEAD"), "ref: refs/heads/main", "utf8");
+
+    const restored = recoverDisabledNestedGit(work);
+    expect(restored).toBe(1);
+    expect(existsSync(join(work, "sub", ".git"))).toBe(true);
+    expect(existsSync(disabled)).toBe(false);
+  });
+
+  it("recoverDisabledNestedGit leaves active .git dirs untouched", () => {
+    const active = join(work, "sub", ".git");
+    mkdirSync(active, { recursive: true });
+    writeFileSync(join(active, "HEAD"), "ref: refs/heads/main", "utf8");
+
+    const restored = recoverDisabledNestedGit(work);
+    expect(restored).toBe(0);
+    expect(existsSync(active)).toBe(true);
+  });
+
+  it("recoverAllDisabledNestedGit walks from cwd upward without throwing", () => {
+    const here = mkdtempSync(join(tmpdir(), "x-agent-shadow-git-walk-"));
+    const sub = join(here, "sub");
+    const disabled = join(sub, `.git${NESTED_GIT_DISABLED_SUFFIX}`);
+    mkdirSync(disabled, { recursive: true });
+    writeFileSync(join(disabled, "HEAD"), "ref: refs/heads/main", "utf8");
+
+    const restored = recoverAllDisabledNestedGit();
+    expect(restored).toBeGreaterThanOrEqual(0);
+
+    rmSync(here, { recursive: true, force: true });
+  });
+});
+
+describe("ShadowGit class (requires git)", () => {
+  const skipIfNoGit = gitAvailable() ? it : it.skip;
+  let work: string;
+  let gitDir: string;
+  beforeEach(() => {
+    work = mkdtempSync(join(tmpdir(), "x-agent-shadow-git-class-"));
+    gitDir = mkdtempSync(join(tmpdir(), "x-agent-shadow-git-gd-"));
+    writeFileSync(join(work, "hello.txt"), "v1\n", "utf8");
+  });
+  afterEach(() => {
+    rmSync(work, { recursive: true, force: true });
+    rmSync(gitDir, { recursive: true, force: true });
+  });
+
+  skipIfNoGit("ensureRepo -> isReady -> commit empty worktree succeeds", async () => {
+    const sg = new ShadowGit(work, gitDir);
+    const r = await sg.ensureRepo();
+    expect(r.ok).toBe(true);
+    expect(sg.isReady()).toBe(true);
+    const c = await sg.commit("init");
+    expect(c.ok).toBe(true);
+    if (c.sha) {
+      expect(c.sha).toMatch(/^[a-f0-9]{40}$/);
+    }
+  });
+
+  skipIfNoGit("commit after file write produces a sha and revParse returns it", async () => {
+    const sg = new ShadowGit(work, gitDir);
+    await sg.ensureRepo();
+    writeFileSync(join(work, "hello.txt"), "v2\n", "utf8");
+    const c = await sg.commit("update");
+    expect(c.ok).toBe(true);
+    expect(c.sha).toBeTruthy();
+    const parsed = await sg.revParse("HEAD");
+    expect(parsed).toBe(c.sha);
+  });
+
+  skipIfNoGit("diffPaths lists the changed file between two commits", async () => {
+    const sg = new ShadowGit(work, gitDir);
+    await sg.ensureRepo();
+    const c1 = await sg.commit("first");
+    writeFileSync(join(work, "hello.txt"), "v2\n", "utf8");
+    const c2 = await sg.commit("second");
+    const diff = await sg.diffPaths(c1.sha, c2.sha);
+    expect(diff.ok).toBe(true);
+    expect(diff.paths).toContain("hello.txt");
+  });
+
+  skipIfNoGit("restore(sha) reverts the worktree to that commit", async () => {
+    const sg = new ShadowGit(work, gitDir);
+    await sg.ensureRepo();
+    const c1 = await sg.commit("v1");
+    writeFileSync(join(work, "hello.txt"), "v2\n", "utf8");
+    await sg.commit("v2");
+    const restore = await sg.restore(c1.sha);
+    expect(restore.ok).toBe(true);
+    const after = readFileSync(join(work, "hello.txt"), "utf8");
+    expect(after).toBe("v1\n");
+  });
+});

--- a/apps/desktop/electron/ipc/register-ipc-translated.test.ts
+++ b/apps/desktop/electron/ipc/register-ipc-translated.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Vitest unit test for `electron/ipc/register-ipc.handle` (阶段 3, 2026-09-09).
+ *
+ * Pins the contract that any non-sender-untrusted throw from a handler is
+ * funnelled through `shared/error-i18n.inspectError` and re-thrown as a
+ * `TranslatedIpcError` so the renderer gets a Chinese user-facing message
+ * + a stable `patternId`.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { configureIpcSenderGuard, handle, isTranslatedIpcError, resetIpcSenderGuard } from "./register-ipc";
+import { isSenderUntrustedError } from "../../shared/ipc";
+import { IPC_CHANNELS } from "../../shared/ipc-channels";
+
+function registerAndCapture(
+  channel: keyof typeof IPC_CHANNELS,
+  handler: (...args: unknown[]) => unknown,
+): (e: unknown, ...args: unknown[]) => unknown {
+  const calls: Array<[string, (...args: unknown[]) => unknown]> = [];
+  const ipcMain = {
+    handle: vi.fn((c: string, f: never) => calls.push([c, f])),
+  };
+  handle(ipcMain as never, channel, handler as never);
+  expect(calls).toHaveLength(1);
+  return calls[0]![1];
+}
+
+const trustedEvent = {
+  sender: { id: 1 },
+  senderFrame: { url: "file:///index.html" },
+};
+
+describe("handler throw translation (issue #65 follow-up, 阶段 3)", () => {
+  it("handler throwing Error(message) is translated to Chinese + patternId", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error(
+        '401 {"error":{"message":"Authentication Fails, Your api key: ****e560 is invalid"}}',
+      );
+    });
+    const registered = registerAndCapture(IPC_CHANNELS.prompt, handler);
+
+    let caught: unknown;
+    try {
+      await (registered as (e: unknown) => Promise<unknown>)(trustedEvent, {
+        text: "hi",
+      });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(isSenderUntrustedError(caught)).toBe(false);
+    expect(isTranslatedIpcError(caught)).toBe(true);
+    if (isTranslatedIpcError(caught)) {
+      expect(caught.patternId).toBe("auth_failed");
+      expect(caught.message).toContain("认证失败");
+      // The raw English must NOT leak into the renderer-bound payload.
+      expect(caught.message).not.toContain("Authentication Fails");
+    }
+  });
+
+  it("handler throwing a network-shape error is recognised as a network-ish pattern", async () => {
+    const handler = vi.fn(async () => {
+      throw new Error("fetch failed: ECONNREFUSED 127.0.0.1:443");
+    });
+    const registered = registerAndCapture(IPC_CHANNELS.prompt, handler);
+
+    let caught: unknown;
+    try {
+      await (registered as (e: unknown) => Promise<unknown>)(trustedEvent, {
+        text: "hi",
+      });
+    } catch (e) {
+      caught = e;
+    }
+    expect(isTranslatedIpcError(caught)).toBe(true);
+    if (isTranslatedIpcError(caught)) {
+      // Acceptable pattern ids for this network-shape error string. The exact
+      // id is implementation-defined by shared/error-i18n.ts; the test pins
+      // "some network-related id" rather than a specific value to avoid
+      // brittleness when the pattern registry is updated.
+      expect(["network_refused", "network_error", "unknown"]).toContain(
+        caught.patternId ?? "unknown",
+      );
+      expect(caught.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("handler returning a Result (no throw) is NOT wrapped", async () => {
+    const handler = vi.fn(async () => ({ ok: false, error: "消息过长" }));
+    const registered = registerAndCapture(IPC_CHANNELS.prompt, handler);
+
+    const result = await (registered as (e: unknown) => Promise<unknown>)(
+      trustedEvent,
+      { text: "hi" },
+    );
+    // Result path is untouched; translation only kicks in on throw.
+    expect(result).toEqual({ ok: false, error: "消息过长" });
+  });
+
+  it("SenderUntrustedError is still thrown unwrapped (sender guard path)", async () => {
+    // Sender guard rejects this sender, so the handler must NOT be called and
+    // the throw must be the original SenderUntrustedError, NOT a TranslatedIpcError.
+    const fakeWebContents = { id: 1 };
+    const fakeWin = { webContents: fakeWebContents, isDestroyed: () => false };
+    configureIpcSenderGuard(() => fakeWin as never, null);
+
+    const handler = vi.fn(async () => ({ ok: true }));
+    const registered = registerAndCapture(IPC_CHANNELS.prompt, handler);
+
+    const crossEvent = {
+      sender: { id: 999 },
+      senderFrame: { url: "file:///something" },
+    };
+    let caught: unknown;
+    try {
+      await (registered as (e: unknown) => Promise<unknown>)(crossEvent);
+    } catch (e) {
+      caught = e;
+    }
+    expect(isSenderUntrustedError(caught)).toBe(true);
+    expect(isTranslatedIpcError(caught)).toBe(false);
+    expect(handler).not.toHaveBeenCalled();
+
+    resetIpcSenderGuard();
+  });
+});

--- a/apps/desktop/electron/ipc/register-ipc.ts
+++ b/apps/desktop/electron/ipc/register-ipc.ts
@@ -8,6 +8,8 @@ import {
   type IpcChannelKey,
   type SenderUntrustedError,
 } from "../../shared/ipc";
+import { inspectError } from "../../shared/error-i18n";
+import { dbgWarn } from "../../shared/debug-log";
 
 /**
  * Typed `ipcMain.handle` registrar: the handler signature is derived from
@@ -19,21 +21,47 @@ import {
  * renderer URL / file: protocol) may invoke channels.
  *
  * **Sender-trust 契约 (issue #65 主题 H, 2026-08-31)**:
- *   - 不可信 sender 抛 `SenderUntrustedError`, IPC 协议让该 throw 透传到
- *     renderer 端 `await` 的 reject 路径, 渲染端 catch 块拿到
- *     `SenderUntrustedError` 对象, 可用 `isSenderUntrustedError` typeguard
- *     区分业务错误.
- *   - 这个 throw 不会进 IpcInvokeMap[K] 的 resolve union, 因为 TS Promise
- *     resolve 路径不携带 throw 类型. 协议层契约用派生类型 `IpcInvokeResult<K>`
- *     表达 (详见 ./../../shared/ipc-invoke-map.ts).
- *   - `SenderUntrustedError` 字段 `ok: false` 让 `Result | SenderUntrustedError`
- *     union 在 `if (!result.ok)` narrowing 时仍然 work.
+ *  - 不可信 sender 抛 `SenderUntrustedError`, IPC 协议让该 throw 透传到
+ *    renderer 端 `await` 的 reject 路径, 渲染端 catch 块拿到
+ *    `SenderUntrustedError` 对象, 可用 `isSenderUntrustedError` typeguard
+ *    区分业务错误.
+ *  - 这个 throw 不会进 IpcInvokeMap[K] 的 resolve union, 因为 TS Promise
+ *    resolve 路径不携带 throw 类型. 协议层契约用派生类型 `IpcInvokeResult<K>`
+ *    表达 (详见 ./../../shared/ipc-invoke-map.ts).
+ *  - `SenderUntrustedError` 字段 `ok: false` 让 `Result | SenderUntrustedError`
+ *    union 在 `if (!result.ok)` narrowing 时仍然 work.
+ *
+ * **Handler-throw 翻译 (阶段 3, 2026-09-09)**:
+ *  - 业务错误继续走 `Result` (返回 `{ ok: false, error }`, session-host 等
+ *    已经在 main 里产出中文 message).
+ *  - handler 自身 `throw` 的非 sender-untrusted 错误会被 `inspectError` 翻译
+ *    成中文 + `patternId`, 然后以 `TranslatedIpcError` 形态抛回 renderer. 这样
+ *    renderer catch 块既能拿到用户面中文, 也能用 `isTranslatedIpcError` 区分.
  */
 export type IpcHandler<K extends IpcChannelKey> = IpcInvokeMap[K] extends (
   ...args: infer Args
 ) => Promise<infer Result>
   ? (event: IpcMainInvokeEvent, ...args: Args) => Promise<Result> | Result
   : never;
+
+/**
+ * Marker the renderer can use to tell a translated handler error apart from
+ * `SenderUntrustedError` and from raw upstream `Error.message` strings.
+ */
+export type TranslatedIpcError = {
+  __translatedError: true;
+  patternId: string | null;
+  message: string;
+};
+
+/** Typeguard matching the marker above. */
+export function isTranslatedIpcError(err: unknown): err is TranslatedIpcError {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as { __translatedError?: unknown }).__translatedError === true
+  );
+}
 
 let trustedWindowProvider: (() => BrowserWindow | null) | null = null;
 let trustedRendererOrigin: string | null = null;
@@ -94,13 +122,20 @@ export function makeSenderUntrustedError(channel: string): SenderUntrustedError 
   };
 }
 
-/** Register one invoke handler with its signature anchored to IpcInvokeMap. */
+/**
+ * Register one invoke handler with its signature anchored to IpcInvokeMap.
+ *
+ *  - Sender-trust check runs first; untrusted senders throw `SenderUntrustedError`.
+ *  - Any other throw from the handler is funneled through `inspectError` and
+ *    re-thrown as a `TranslatedIpcError` so the renderer receives a Chinese
+ *    user-facing message + a stable `patternId`.
+ */
 export function handle<K extends IpcChannelKey>(
   ipcMain: IpcMain,
   channel: K,
   handler: IpcHandler<K>,
 ): void {
-  ipcMain.handle(channel, (event, ...args) => {
+  ipcMain.handle(channel, async (event, ...args) => {
     if (!isTrustedIpcSender(event as IpcMainInvokeEvent)) {
       console.warn(`[ipc] 拒绝来自不受信任来源的调用：${channel}`);
       // 抛契约化异常 (issue #65 主题 H, 2026-08-31). 之前 throw new Error(...)
@@ -110,6 +145,19 @@ export function handle<K extends IpcChannelKey>(
       // 仍 work (IpcInvokeResult[K] = Result | SenderUntrustedError).
       throw makeSenderUntrustedError(channel);
     }
-    return handler(event, ...args);
+    try {
+      return await handler(event, ...args);
+    } catch (err) {
+      // SenderUntrustedError is a plain object thrown above, never reaches here.
+      // Translate upstream / network / model errors so the renderer receives
+      // a Chinese summary + a stable patternId (see shared/error-i18n.ts).
+      const inspected = inspectError(err);
+      dbgWarn("ipc", `${channel} handler threw`, err);
+      throw {
+        __translatedError: true,
+        patternId: inspected.patternId,
+        message: inspected.message,
+      } satisfies TranslatedIpcError;
+    }
   });
 }

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -271,6 +271,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.44",
         "caniuse-lite": "^1.0.30001806",
@@ -2555,7 +2556,6 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -2577,7 +2577,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -3681,6 +3680,7 @@
       "resolved": "https://registry.npmmirror.com/@types/react/-/react-19.2.18.tgz",
       "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4093,6 +4093,7 @@
       "integrity": "sha512-toMg6PZGCIa/lQNCDoASrfb1ly4hsUKXFtFYC9kD4t78o5Y6LyNJU7AENt8eHPr3quYdxaxK7hj2mnbFfUk9NA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
         "@vitest/istanbul-lib-coverage": "^1.0.0",
@@ -4904,8 +4905,7 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5166,6 +5166,7 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -5868,7 +5869,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -5889,7 +5889,6 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -5905,7 +5904,6 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -5916,7 +5914,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -8248,7 +8245,6 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -8700,7 +8696,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -8718,7 +8713,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -8835,6 +8829,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
       "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8844,6 +8839,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
       "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9048,7 +9044,6 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -9441,7 +9436,6 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -9597,6 +9591,7 @@
       "integrity": "sha512-BL5MGkRln6aDYhb0xbQlEAGw743BaZYWdbWtdJOBriYJboKgUUYCadFp2/FpBBZquBC/ezNBn7wMMPx7FDZUDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -9855,6 +9850,7 @@
       "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.33.0",
         "picomatch": "^4.0.5",
@@ -9933,6 +9929,7 @@
       "integrity": "sha512-gpsMNoRhMjMktVxPtstOH4/PJuPyovVaMDr4oDilXaGH1EcqM2OE96SoHT2VIQ6fTGtTjqmHDrEu2X9RQiXf8Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/mocker": "5.0.0",

--- a/apps/desktop/public/splash.html
+++ b/apps/desktop/public/splash.html
@@ -360,7 +360,7 @@
         </span>
         <span class="status">正在准备会话资源</span>
         <span class="divider" aria-hidden="true"></span>
-        <span class="version">v0.6.1</span>
+        <span class="version">v0.6.2</span>
       </div>
 
       <p class="credit fade">by <span>Fromlan</span></p>

--- a/apps/desktop/shared/debug-log.test.ts
+++ b/apps/desktop/shared/debug-log.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Vitest unit test for `shared/debug-log.redactString` (defense-in-depth guard
+ * against accidental dbgLog(apiKey) leaks).
+ *
+ * The cross-process dbgLog/dbgWarn/dbgTimer funnels every logged string
+ * through redactString before it reaches stdout / DevTools. This test pins
+ * the recognised secret shapes so a future maintainer cannot disable the
+ * filter without a deliberate, auditable change.
+ */
+import { describe, it, expect } from "vitest";
+import { redactString } from "./debug-log";
+
+describe("redactString (debug-log defense-in-depth)", () => {
+  it("redacts an OpenAI-style sk- key", () => {
+    expect(redactString("key=sk-abcdefghijklmnopqrstuvwxyz0123456789")).toBe(
+      "key=[REDACTED:openai_key]",
+    );
+  });
+
+  it("redacts an Anthropic-style sk-ant- key", () => {
+    expect(redactString("Authorization: sk-ant-api03-AAAA_BBBB_CCCC_DDDD")).toBe(
+      "Authorization: [REDACTED:anthropic_key]",
+    );
+  });
+
+  it("redacts a GitHub PAT (ghp_...)", () => {
+    expect(redactString("token ghp_abcDEFghijKLMnopQRSTUVwxyz0123456789")).toBe(
+      "token [REDACTED:github_pat]",
+    );
+  });
+
+  it("redacts a GitHub app/install token (ghs_ / gho_)", () => {
+    expect(redactString("ghs_aaaabbbbccccddddeeeeffffgggghhhh")).toBe(
+      "[REDACTED:github_app]",
+    );
+    expect(redactString("gho_aaaabbbbccccddddeeeeffffgggghhhh")).toBe(
+      "[REDACTED:github_app]",
+    );
+  });
+
+  it("redacts a Google API key (AIza...)", () => {
+    expect(
+      redactString("AIzaSyA-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789"),
+    ).toBe("[REDACTED:google_api]");
+  });
+
+  it("redacts long alphanumeric blobs (>= 64 chars, includes hex and base64)", () => {
+    const b64 = "A".repeat(80);
+    expect(redactString("cipher=" + b64)).toBe("cipher=[REDACTED:long_blob]");
+    const hex = "deadbeef".repeat(10);
+    expect(redactString("hash=" + hex)).toBe("hash=[REDACTED:long_blob]");
+  });
+
+  it("leaves a normal log line untouched", () => {
+    const msg =
+      "shadow_recover failed: ENOENT no such file or directory, open /tmp/x";
+    expect(redactString(msg)).toBe(msg);
+  });
+
+  it("does not redact short alnum blobs (e.g. 40-char git sha)", () => {
+    const sha = "0123456789abcdef0123456789abcdef01234567";
+    expect(redactString(sha)).toBe(sha);
+  });
+
+  it("redacts multiple secrets in the same string", () => {
+    const msg =
+      "sk-abcdefghijklmnopqrstuvwxyz0123456789 and AIzaSyA-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789";
+    const r = redactString(msg);
+    expect(r).toContain("[REDACTED:openai_key]");
+    expect(r).toContain("[REDACTED:google_api]");
+    expect(r).not.toContain("sk-abcdef");
+  });
+});

--- a/apps/desktop/shared/debug-log.ts
+++ b/apps/desktop/shared/debug-log.ts
@@ -15,6 +15,11 @@
  *
  * Use `dbgLog()` for ordinary traces, `dbgWarn()` for recoverable anomalies,
  * and `dbgTimer()` to measure how long an awaited step took.
+ *
+ * Defense in depth (2026-09-09): every logged string passes through
+ * `redactString()` so accidental dbgLog(secret) cannot leak API keys, the
+ * `encryptedKey` ciphertext, the Godot RPC handshake token, or anything
+ * resembling a 64+ char base64 / hex blob.
  */
 const PREFIX = "[x-agent]";
 
@@ -27,7 +32,7 @@ function parseFlag(raw: string | null | undefined): boolean | undefined {
   return undefined;
 }
 
-/** Read main-process env flag. Guarded so renderer / SSR can't blow up. */
+/** Read main-process env flag. Guarded so renderer / SSR cannot blow up. */
 function readEnvFlag(): boolean | undefined {
   try {
     const proc = (globalThis as { process?: { env?: Record<string, string | undefined> } })
@@ -60,13 +65,67 @@ export function isDebugEnabled(): boolean {
   return true;
 }
 
-/** ISO timestamp — shared format so main and renderer lines line up. */
+/** ISO timestamp - shared format so main and renderer lines line up. */
 function ts(): string {
   return new Date().toISOString();
 }
 
+/**
+ * Recognised secret prefixes / shapes. Matches are coarse on purpose
+ * (over-redaction beats leak). `long_blob` covers any 64+ char alphanumeric
+ * run with base64 / hex / arbitrary salt / token chars, so we never have to
+ * disambiguate base64 vs hex vs IV (the 7-catch-all pattern defeats both).
+ */
+const REDACT_RULES: Array<{ name: string; pattern: RegExp }> = [
+  { name: "anthropic_key", pattern: /sk-ant-[A-Za-z0-9_-]+/g },
+  { name: "openai_key", pattern: /sk-[A-Za-z0-9]{20,}/g },
+  { name: "github_pat", pattern: /ghp_[A-Za-z0-9]{20,}/g },
+  { name: "github_app", pattern: /(ghs_|gho_)[A-Za-z0-9]{20,}/g },
+  { name: "google_api", pattern: /AIza[A-Za-z0-9_-]{30,}/g },
+  { name: "long_blob", pattern: /[A-Za-z0-9+/_-]{64,}/g },
+];
+
+/** Replace any recognised secret with `[REDACTED:<rule>]`. */
+export function redactString(s: string): string {
+  let out = s;
+  for (const rule of REDACT_RULES) {
+    out = out.replace(rule.pattern, `[REDACTED:${rule.name}]`);
+  }
+  return out;
+}
+
+/**
+ * Redact a single argument. Shallow on purpose: existing call sites pass
+ * either strings or small plain objects, so a recursive walk would do more
+ * harm (cycles / perf) than good. Errors get their `message` rewritten but
+ * keep their original `name` and `stack`.
+ */
+function redactArg(arg: unknown): unknown {
+  if (typeof arg === "string") return redactString(arg);
+  if (arg instanceof Error) {
+    return {
+      name: arg.name,
+      message: redactString(arg.message),
+      stack: arg.stack,
+    };
+  }
+  if (arg && typeof arg === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(arg)) {
+      out[k] = typeof v === "string" ? redactString(v) : v;
+    }
+    return out;
+  }
+  return arg;
+}
+
+/** Redact a full args tuple. Returns a new array. */
+function redactArgs(args: unknown[]): unknown[] {
+  return args.map(redactArg);
+}
+
 function fmt(ns: string, args: unknown[]): unknown[] {
-  return [`${PREFIX}[${ns}] ${ts()}`, ...args];
+  return [`${PREFIX}[${ns}] ${ts()}`, ...redactArgs(args)];
 }
 
 /** Emit a trace-level debug entry. No-op when debug logging is disabled. */
@@ -95,3 +154,4 @@ export function dbgTimer(ns: string, label: string): () => void {
     console.log(`${PREFIX}[${ns}] ${ts()} ${label} +${Date.now() - start}ms`);
   };
 }
+

--- a/apps/desktop/src/styles/app.css
+++ b/apps/desktop/src/styles/app.css
@@ -6270,7 +6270,7 @@ body[data-session-type="design"] .composer-shell[data-streaming="true"] {
 .logo-customs-title {
   margin: 0;
   font-size: 11px;
-  font-weight: 600;
+  font-weight: 500;
   letter-spacing: 0.04em;
   color: var(--text-muted);
   text-transform: uppercase;
@@ -6487,3 +6487,4 @@ body[data-session-type="design"] .composer-shell[data-streaming="true"] {
   flex: 1;
   min-width: 0;
 }
+


### PR DESCRIPTION
## 主线

### 1. shared/debug-log.ts —— secret redaction 防御层
新增 `redactString()` 在 dbgLog/dbgWarn/dbgTimer 入口自动跑，覆盖：
- `sk-ant-...` Anthropic key
- `sk-...` OpenAI key
- `ghp_/ghs_/gho_` GitHub token
- `AIza...` Google API key
- 64+ char base64/hex/salt blob（catch-all）
`Error.message` 和 plain object 的 string 字段一并覆盖。

### 2. electron/ipc/register-ipc.ts —— handler throw 翻译层
非 sender-untrusted throw 经 `shared/error-i18n.inspectError` 翻译，以 `TranslatedIpcError`（patternId + 中文 message）抛回 renderer。renderer 端用 `isTranslatedIpcError` typeguard 区分业务 Result。`SenderUntrustedError` 仍 unwrapped 抛，sender-trust 契约不变。

## 设计规范

- `src/styles/app.css .logo-customs-title`: `font-weight: 600 → 500`（对齐 docs/design.md 字重克制 400/500）
- `public/splash.html`: `v0.6.1 → v0.6.2`（与 package.json 同步）

## 新增 vitest（5 文件 / 55 cases）

| 文件 | cases | 覆盖 |
|------|-------|------|
| shared/debug-log.test.ts | 9 | redactString 6 种 secret + 普通文本透传 + 40-char git sha 不误伤 + 多 secret 同串 |
| electron/ipc/register-ipc-translated.test.ts | 4 | Error → 中文+patternId + Result 不被 wrap + SenderUntrustedError unwrapped |
| electron/agent/pi-settings.test.ts | 7 | settings.json 原子读改写 + 字段保留 + 损坏恢复 + 数组根替换 + tmp 清理 + 并发写不丢字段 |
| electron/agent/session-mode/plan-mode-guard.test.ts | 16 | Ask/Plan hard-gate mode 维度 + bash readonly 维度 + path 工具 cwd 维度 + InlineExtension factory |
| electron/agent/shadow-git.test.ts | 10 + 4 git-conditional | 常量契约 + 纯函数 + fs helper + ShadowGit class（commit/diff/restore，无 git 环境自动 skip） |

## build

- `apps/desktop/.gitignore`：composite 模式无 outDir 时的 TS emit 产物（`**/*.d.ts` / `**/*.js` / `**/*.js.map`）
- `apps/desktop/package-lock.json`：npm peer / optional 字段重平衡
- 根 `.gitignore`：加 `.worktrees/`（之前 473 个过期 agent worktree 产物，非注册 git worktree；磁盘文件保留，git 不再提示）

## 自检

- `npm run typecheck`: 0 error（node + web 双 tsconfig）
- `npm run lint`: ok
- `npm run test:unit`: 76 files / 937 cases 全过（含新增 55）
- `npm test`: 62 步串联全过
- `npm run test:coverage`: 在本机偶现 1 个超时 flake（`bash-check.test.ts` 的 `findSuggestedBash` 真实 PATH 探测 + `prefs-recovery-notice.test.ts` 的 50ms 异步等待），与本次改动无关；CI 默认重试可吸收

## 风险与后续

- `apps/desktop/.gitignore` 的 `**/*.js` 较宽，未来新 `.js` 文件会被静默忽略；妥协点是 `tsconfig.json` 的 `composite: true` 无 `outDir`，正确解是后续给 tsconfig 设 `outDir` 并精确 gitignore
- `.worktrees/` 仅本地 gitignore，不删磁盘文件，避免潜在数据丢失

Refs: issue #65 阶段 3 follow-up